### PR TITLE
🚀 Github CODEOWNERS 설정

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @ASak1104 @shoeone96 and @IjjS will be requested for
+# review when someone opens a pull request.
+* @Team-SilverTown/Backend


### PR DESCRIPTION
- 현재 Backend 팀을 기준으로 reviewers auto assign 설정
- default로 @Team-SilverTown/backend 가 태그되고
- 필요에 따라 개개인에 대한 reviewer를 추가로 지정하는 것도 좋아보임