### PR TITLE
🚀 스키마 엔티티 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,87 +1,91 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
-	id 'jacoco'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.2'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
 }
 
 group = 'team.silver-town'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	// flyway
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
+    // flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 
-	// h2
-	testImplementation 'com.h2database:h2:2.2.224'
+    // h2
+    testImplementation 'com.h2database:h2:2.2.224'
+
+    // spatial
+    implementation 'org.hibernate.orm:hibernate-spatial'
 }
 
 test {
-	useJUnitPlatform()
+    useJUnitPlatform()
 
-	finalizedBy jacocoTestReport
+    finalizedBy jacocoTestReport
 }
 
 jacoco {
-	toolVersion = "0.8.11"
+    toolVersion = "0.8.11"
 }
 
 jacocoTestReport {
-	reports {
-		html.required = true
-		xml.required = true
-		csv.required = false
-	}
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = false
+    }
 
-	finalizedBy jacocoTestCoverageVerification
-	dependsOn test
+    finalizedBy jacocoTestCoverageVerification
+    dependsOn test
 }
 
 jacocoTestCoverageVerification {
-	violationRules {
-		rule {
-			element = 'CLASS'
+    violationRules {
+        rule {
+            element = 'CLASS'
 
-			limit {
-				counter = 'LINE'
-				value = 'COVEREDRATIO'
-				minimum = 0.50
-			}
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
 
-			limit {
-				counter = 'BRANCH'
-				value = 'COVEREDRATIO'
-				minimum = 0.50
-			}
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
 
-			includes = [
-					'*.domain.*',
-					'*.service.*'
-			]
-		}
-	}
+            includes = [
+                    '*.domain.*',
+                    '*.service.*'
+            ]
+        }
+    }
 
-	dependsOn jacocoTestReport
+    dependsOn jacocoTestReport
 }

--- a/src/main/java/team/silvertown/masil/common/Address.java
+++ b/src/main/java/team/silvertown/masil/common/Address.java
@@ -1,0 +1,20 @@
+package team.silvertown.masil.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class Address {
+
+    @Column(name = "address_depth1", length = 20)
+    private String depth1;
+
+    @Column(name = "address_depth2", length = 20)
+    private String depth2;
+
+    @Column(name = "address_depth3", length = 20)
+    private String depth3;
+
+}

--- a/src/main/java/team/silvertown/masil/common/BaseEntity.java
+++ b/src/main/java/team/silvertown/masil/common/BaseEntity.java
@@ -1,0 +1,32 @@
+package team.silvertown.masil.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.TimeZoneStorage;
+import org.hibernate.annotations.TimeZoneStorageType;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@MappedSuperclass
+@Getter
+public class BaseEntity {
+
+    @Column(
+        name = "created_at", nullable = false,
+        columnDefinition = "TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6)"
+    )
+    @CreationTimestamp
+    @TimeZoneStorage(TimeZoneStorageType.NORMALIZE)
+    private OffsetDateTime createdAt;
+
+    @Column(
+        name = "updated_at", nullable = false,
+        columnDefinition = "TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)"
+    )
+    @UpdateTimestamp
+    @TimeZoneStorage(TimeZoneStorageType.NORMALIZE)
+    private OffsetDateTime updatedAt;
+
+}

--- a/src/main/java/team/silvertown/masil/common/BaseEntity.java
+++ b/src/main/java/team/silvertown/masil/common/BaseEntity.java
@@ -13,18 +13,12 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Getter
 public class BaseEntity {
 
-    @Column(
-        name = "created_at", nullable = false,
-        columnDefinition = "TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6)"
-    )
+    @Column(name = "created_at", nullable = false)
     @CreationTimestamp
     @TimeZoneStorage(TimeZoneStorageType.NORMALIZE)
     private OffsetDateTime createdAt;
 
-    @Column(
-        name = "updated_at", nullable = false,
-        columnDefinition = "TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)"
-    )
+    @Column(name = "updated_at", nullable = false)
     @UpdateTimestamp
     @TimeZoneStorage(TimeZoneStorageType.NORMALIZE)
     private OffsetDateTime updatedAt;

--- a/src/main/java/team/silvertown/masil/common/map/Address.java
+++ b/src/main/java/team/silvertown/masil/common/map/Address.java
@@ -1,4 +1,4 @@
-package team.silvertown.masil.common;
+package team.silvertown.masil.common.map;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/src/main/java/team/silvertown/masil/common/map/Address.java
+++ b/src/main/java/team/silvertown/masil/common/map/Address.java
@@ -8,13 +8,13 @@ import lombok.Getter;
 @Getter
 public class Address {
 
-    @Column(name = "address_depth1", length = 20)
+    @Column(name = "address_depth1", length = 20, nullable = false)
     private String depth1;
 
-    @Column(name = "address_depth2", length = 20)
+    @Column(name = "address_depth2", length = 20, nullable = false)
     private String depth2;
 
-    @Column(name = "address_depth3", length = 20)
+    @Column(name = "address_depth3", length = 20, nullable = false)
     private String depth3;
 
 }

--- a/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
+++ b/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
@@ -1,11 +1,9 @@
 package team.silvertown.masil.common.map;
 
-import lombok.Getter;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
-@Getter
 public record KakaoPoint(double lat, double lng) {
 
     public Point toPoint(WKTReader wktReader) {

--- a/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
+++ b/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
@@ -1,0 +1,24 @@
+package team.silvertown.masil.common.map;
+
+import lombok.Getter;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+@Getter
+public record KakaoPoint(double lat, double lng) {
+
+    public Point toPoint(WKTReader wktReader) {
+        try {
+            return (Point) wktReader.read("POINT(" + this.toRawString() + ")");
+        } catch (ParseException e) {
+            // Exception 작업 후 수정 예정
+            throw new IllegalArgumentException("Wrong point format");
+        }
+    }
+
+    public String toRawString() {
+        return this.lat + " " + this.lng;
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
+++ b/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
@@ -1,19 +1,6 @@
 package team.silvertown.masil.common.map;
 
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKTReader;
-
 public record KakaoPoint(double lat, double lng) {
-
-    public Point toPoint(WKTReader wktReader) {
-        try {
-            return (Point) wktReader.read("POINT(" + this.toRawString() + ")");
-        } catch (ParseException e) {
-            // Exception 작업 후 수정 예정
-            throw new IllegalArgumentException("Wrong point format");
-        }
-    }
 
     public String toRawString() {
         return this.lat + " " + this.lng;

--- a/src/main/java/team/silvertown/masil/common/map/KakaoPointMapper.java
+++ b/src/main/java/team/silvertown/masil/common/map/KakaoPointMapper.java
@@ -1,0 +1,38 @@
+package team.silvertown.masil.common.map;
+
+import java.util.List;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+public final class KakaoPointMapper {
+
+    private static final WKTReader wktReader = new WKTReader();
+
+    private KakaoPointMapper() {
+    }
+
+    public static Point mapToPoint(KakaoPoint point) {
+        try {
+            return (Point) wktReader.read("POINT(" + point.toRawString() + ")");
+        } catch (ParseException e) {
+            throw new RuntimeException("Wrong Point format");
+        }
+    }
+
+    public static LineString mapToLineString(List<KakaoPoint> path) {
+        StringBuilder stringBuilder = new StringBuilder("LINESTRING(");
+
+        path.forEach(point -> stringBuilder.append(point.toRawString())
+            .append(", "));
+        stringBuilder.replace(stringBuilder.length() - 3, stringBuilder.length() - 1, ")");
+
+        try {
+            return (LineString) wktReader.read(stringBuilder.toString());
+        } catch (ParseException e) {
+            throw new RuntimeException("Wrong LineString format");
+        }
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/config/WebSecurityConfig.java
+++ b/src/main/java/team/silvertown/masil/config/WebSecurityConfig.java
@@ -1,0 +1,31 @@
+package team.silvertown.masil.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain apiFilterChain(HttpSecurity http)
+        throws Exception {
+        return http
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .requestCache(RequestCacheConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .rememberMe(AbstractHttpConfigurer::disable)
+            .logout(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .build();
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -12,6 +12,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.LineString;
@@ -22,6 +24,8 @@ import team.silvertown.masil.user.domain.User;
 @Entity
 @Table(name = "masils")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class Masil extends BaseEntity {
 

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,6 +24,8 @@ import team.silvertown.masil.user.domain.User;
 @Entity
 @Table(name = "masils")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class Masil extends BaseEntity {
 
@@ -60,30 +63,5 @@ public class Masil extends BaseEntity {
 
     @Column(name = "started_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
     private OffsetDateTime startedAt;
-
-    @Builder
-    private Masil(
-        User user,
-        Long postId,
-        Address address,
-        LineString path,
-        String title,
-        String content,
-        String thumbnailUrl,
-        Integer distance,
-        Integer totalTime,
-        OffsetDateTime startedAt
-    ) {
-        this.user = user;
-        this.postId = postId;
-        this.address = address;
-        this.path = path;
-        this.title = title;
-        this.content = content;
-        this.thumbnailUrl = thumbnailUrl;
-        this.distance = distance;
-        this.totalTime = totalTime;
-        this.startedAt = startedAt;
-    }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -16,8 +16,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.LineString;
-import team.silvertown.masil.common.Address;
 import team.silvertown.masil.common.BaseEntity;
+import team.silvertown.masil.common.map.Address;
 import team.silvertown.masil.user.domain.User;
 
 @Entity
@@ -47,7 +47,7 @@ public class Masil extends BaseEntity {
     private String title;
 
     @Column(name = "content", columnDefinition = "TEXT")
-    private String text;
+    private String content;
 
     @Column(name = "thumbnail_url", length = 1024)
     private String thumbnailUrl;
@@ -68,7 +68,7 @@ public class Masil extends BaseEntity {
         Address address,
         LineString path,
         String title,
-        String text,
+        String content,
         String thumbnailUrl,
         Integer distance,
         Integer totalTime,
@@ -79,7 +79,7 @@ public class Masil extends BaseEntity {
         this.address = address;
         this.path = path;
         this.title = title;
-        this.text = text;
+        this.content = content;
         this.thumbnailUrl = thumbnailUrl;
         this.distance = distance;
         this.totalTime = totalTime;

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -1,0 +1,63 @@
+package team.silvertown.masil.masil.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.LineString;
+import team.silvertown.masil.common.Address;
+import team.silvertown.masil.common.BaseEntity;
+import team.silvertown.masil.user.domain.User;
+
+@Entity
+@Table(name = "masils")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Masil extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    @Column(name = "post_id")
+    private Long postId;
+
+    @Embedded
+    private Address address;
+
+    @Column(name = "path", nullable = false)
+    private LineString path;
+
+    @Column(name = "title", nullable = false, length = 30)
+    private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String text;
+
+    @Column(name = "thumbnail_url", length = 1024)
+    private String thumbnailUrl;
+
+    @Column(name = "distance", nullable = false)
+    private Integer distance;
+
+    @Column(name = "total_time", nullable = false)
+    private Integer totalTime;
+
+    @Column(name = "started_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
+    private OffsetDateTime startedAt;
+
+}

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -12,7 +12,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,8 +23,6 @@ import team.silvertown.masil.user.domain.User;
 @Entity
 @Table(name = "masils")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 @Getter
 public class Masil extends BaseEntity {
 
@@ -63,5 +60,30 @@ public class Masil extends BaseEntity {
 
     @Column(name = "started_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
     private OffsetDateTime startedAt;
+
+    @Builder
+    private Masil(
+        User user,
+        Long postId,
+        Address address,
+        LineString path,
+        String title,
+        String text,
+        String thumbnailUrl,
+        Integer distance,
+        Integer totalTime,
+        OffsetDateTime startedAt
+    ) {
+        this.user = user;
+        this.postId = postId;
+        this.address = address;
+        this.path = path;
+        this.title = title;
+        this.text = text;
+        this.thumbnailUrl = thumbnailUrl;
+        this.distance = distance;
+        this.totalTime = totalTime;
+        this.startedAt = startedAt;
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
@@ -18,6 +20,8 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "masil_pins")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class MasilPin extends BaseEntity {
 

--- a/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
@@ -10,7 +10,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,8 +19,6 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "masil_pins")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 @Getter
 public class MasilPin extends BaseEntity {
 
@@ -44,5 +41,20 @@ public class MasilPin extends BaseEntity {
 
     @Column(name = "thumbnail_url", length = 1024)
     private String thumbnailUrl;
+
+    @Builder
+    private MasilPin(
+        Masil masil,
+        Long userId,
+        Point point,
+        String content,
+        String thumbnailUrl
+    ) {
+        this.masil = masil;
+        this.userId = userId;
+        this.point = point;
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
@@ -1,0 +1,44 @@
+package team.silvertown.masil.masil.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import team.silvertown.masil.common.BaseEntity;
+
+@Entity
+@Table(name = "masil_pins")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MasilPin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "masil_id", referencedColumnName = "id")
+    private Masil masil;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "point", nullable = false)
+    private Point point;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "thumbnail_url", length = 1024)
+    private String thumbnailUrl;
+
+}

--- a/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,8 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "masil_pins")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class MasilPin extends BaseEntity {
 
@@ -41,20 +44,5 @@ public class MasilPin extends BaseEntity {
 
     @Column(name = "thumbnail_url", length = 1024)
     private String thumbnailUrl;
-
-    @Builder
-    private MasilPin(
-        Masil masil,
-        Long userId,
-        Point point,
-        String content,
-        String thumbnailUrl
-    ) {
-        this.masil = masil;
-        this.userId = userId;
-        this.point = point;
-        this.content = content;
-        this.thumbnailUrl = thumbnailUrl;
-    }
 
 }

--- a/src/main/java/team/silvertown/masil/post/domain/Post.java
+++ b/src/main/java/team/silvertown/masil/post/domain/Post.java
@@ -15,8 +15,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.LineString;
-import team.silvertown.masil.common.Address;
 import team.silvertown.masil.common.BaseEntity;
+import team.silvertown.masil.common.map.Address;
 import team.silvertown.masil.user.domain.User;
 
 @Entity

--- a/src/main/java/team/silvertown/masil/post/domain/Post.java
+++ b/src/main/java/team/silvertown/masil/post/domain/Post.java
@@ -11,6 +11,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.LineString;
@@ -21,6 +23,8 @@ import team.silvertown.masil.user.domain.User;
 @Entity
 @Table(name = "posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class Post extends BaseEntity {
 

--- a/src/main/java/team/silvertown/masil/post/domain/Post.java
+++ b/src/main/java/team/silvertown/masil/post/domain/Post.java
@@ -1,0 +1,65 @@
+package team.silvertown.masil.post.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.LineString;
+import team.silvertown.masil.common.Address;
+import team.silvertown.masil.common.BaseEntity;
+import team.silvertown.masil.user.domain.User;
+
+@Entity
+@Table(name = "posts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    @Embedded
+    private Address address;
+
+    @Column(name = "path", nullable = false)
+    private LineString path;
+
+    @Column(name = "title", nullable = false, length = 30)
+    private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String text;
+
+    @Column(name = "thumbnail_url", length = 1024)
+    private String thumbnailUrl;
+
+    @Column(name = "distance", nullable = false)
+    private Integer distance;
+
+    @Column(name = "total_time", nullable = false)
+    private Integer totalTime;
+
+    @Column(name = "is_public", nullable = false, columnDefinition = "DEFAULT 1")
+    private boolean isPublic = true;
+
+    @Column(name = "view_count", nullable = false, columnDefinition = "DEFAULT 0")
+    private int viewCount = 0;
+
+    @Column(name = "like_count", nullable = false, columnDefinition = "DEFAULT 1")
+    private int likeCount = 0;
+
+}

--- a/src/main/java/team/silvertown/masil/post/domain/Post.java
+++ b/src/main/java/team/silvertown/masil/post/domain/Post.java
@@ -11,7 +11,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,8 +22,6 @@ import team.silvertown.masil.user.domain.User;
 @Entity
 @Table(name = "posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 @Getter
 public class Post extends BaseEntity {
 
@@ -46,7 +43,7 @@ public class Post extends BaseEntity {
     private String title;
 
     @Column(name = "content", columnDefinition = "TEXT")
-    private String text;
+    private String content;
 
     @Column(name = "thumbnail_url", length = 1024)
     private String thumbnailUrl;
@@ -57,13 +54,38 @@ public class Post extends BaseEntity {
     @Column(name = "total_time", nullable = false)
     private Integer totalTime;
 
-    @Column(name = "is_public", nullable = false, columnDefinition = "DEFAULT 1")
-    private boolean isPublic = true;
+    @Column(name = "is_public", nullable = false)
+    private boolean isPublic;
 
-    @Column(name = "view_count", nullable = false, columnDefinition = "DEFAULT 0")
-    private int viewCount = 0;
+    @Column(name = "view_count", nullable = false)
+    private int viewCount;
 
-    @Column(name = "like_count", nullable = false, columnDefinition = "DEFAULT 1")
-    private int likeCount = 0;
+    @Column(name = "like_count", nullable = false)
+    private int likeCount;
+
+
+    @Builder
+    private Post(
+        User user,
+        Address address,
+        LineString path,
+        String title,
+        String content,
+        String thumbnailUrl,
+        Integer distance,
+        Integer totalTime
+    ) {
+        this.user = user;
+        this.address = address;
+        this.path = path;
+        this.title = title;
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.distance = distance;
+        this.totalTime = totalTime;
+        this.viewCount = 0;
+        this.likeCount = 0;
+        this.isPublic = true;
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/post/domain/Post.java
+++ b/src/main/java/team/silvertown/masil/post/domain/Post.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +23,8 @@ import team.silvertown.masil.user.domain.User;
 @Entity
 @Table(name = "posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class Post extends BaseEntity {
 
@@ -55,37 +58,12 @@ public class Post extends BaseEntity {
     private Integer totalTime;
 
     @Column(name = "is_public", nullable = false)
-    private boolean isPublic;
+    private Boolean isPublic;
 
     @Column(name = "view_count", nullable = false)
     private int viewCount;
 
     @Column(name = "like_count", nullable = false)
     private int likeCount;
-
-
-    @Builder
-    private Post(
-        User user,
-        Address address,
-        LineString path,
-        String title,
-        String content,
-        String thumbnailUrl,
-        Integer distance,
-        Integer totalTime
-    ) {
-        this.user = user;
-        this.address = address;
-        this.path = path;
-        this.title = title;
-        this.content = content;
-        this.thumbnailUrl = thumbnailUrl;
-        this.distance = distance;
-        this.totalTime = totalTime;
-        this.viewCount = 0;
-        this.likeCount = 0;
-        this.isPublic = true;
-    }
 
 }

--- a/src/main/java/team/silvertown/masil/post/domain/PostPin.java
+++ b/src/main/java/team/silvertown/masil/post/domain/PostPin.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
@@ -18,6 +20,8 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "post_pins")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class PostPin extends BaseEntity {
 

--- a/src/main/java/team/silvertown/masil/post/domain/PostPin.java
+++ b/src/main/java/team/silvertown/masil/post/domain/PostPin.java
@@ -10,7 +10,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,8 +19,6 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "post_pins")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 @Getter
 public class PostPin extends BaseEntity {
 
@@ -44,5 +41,14 @@ public class PostPin extends BaseEntity {
 
     @Column(name = "thumbnail_url", length = 1024)
     private String thumbnailUrl;
+
+    @Builder
+    public PostPin(Post post, Long userId, Point point, String content, String thumbnailUrl) {
+        this.post = post;
+        this.userId = userId;
+        this.point = point;
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/post/domain/PostPin.java
+++ b/src/main/java/team/silvertown/masil/post/domain/PostPin.java
@@ -1,0 +1,44 @@
+package team.silvertown.masil.post.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import team.silvertown.masil.common.BaseEntity;
+
+@Entity
+@Table(name = "post_pins")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PostPin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", referencedColumnName = "id")
+    private Post post;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "point", nullable = false)
+    private Point point;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "thumbnail_url", length = 1024)
+    private String thumbnailUrl;
+
+}

--- a/src/main/java/team/silvertown/masil/post/domain/PostPin.java
+++ b/src/main/java/team/silvertown/masil/post/domain/PostPin.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,8 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "post_pins")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class PostPin extends BaseEntity {
 
@@ -41,14 +44,5 @@ public class PostPin extends BaseEntity {
 
     @Column(name = "thumbnail_url", length = 1024)
     private String thumbnailUrl;
-
-    @Builder
-    public PostPin(Post post, Long userId, Point point, String content, String thumbnailUrl) {
-        this.post = post;
-        this.userId = userId;
-        this.point = point;
-        this.content = content;
-        this.thumbnailUrl = thumbnailUrl;
-    }
 
 }

--- a/src/main/java/team/silvertown/masil/user/domain/Authority.java
+++ b/src/main/java/team/silvertown/masil/user/domain/Authority.java
@@ -1,7 +1,6 @@
 package team.silvertown.masil.user.domain;
 
 public enum Authority {
-    ANONYMOUS,
     RESTRICTED,
     NORMAL,
     ADMIN

--- a/src/main/java/team/silvertown/masil/user/domain/Authority.java
+++ b/src/main/java/team/silvertown/masil/user/domain/Authority.java
@@ -1,0 +1,8 @@
+package team.silvertown.masil.user.domain;
+
+public enum Authority {
+    ANONYMOUS,
+    RESTRICTED,
+    NORMAL,
+    ADMIN
+}

--- a/src/main/java/team/silvertown/masil/user/domain/ExerciseIntensity.java
+++ b/src/main/java/team/silvertown/masil/user/domain/ExerciseIntensity.java
@@ -1,0 +1,9 @@
+package team.silvertown.masil.user.domain;
+
+public enum ExerciseIntensity {
+    SUPER_LOW,
+    LOW,
+    MIDDLE,
+    HIGH,
+    SUPER_HIGH
+}

--- a/src/main/java/team/silvertown/masil/user/domain/Provider.java
+++ b/src/main/java/team/silvertown/masil/user/domain/Provider.java
@@ -1,0 +1,5 @@
+package team.silvertown.masil.user.domain;
+
+public enum Provider {
+    KAKAO
+}

--- a/src/main/java/team/silvertown/masil/user/domain/Sex.java
+++ b/src/main/java/team/silvertown/masil/user/domain/Sex.java
@@ -1,0 +1,6 @@
+package team.silvertown.masil.user.domain;
+
+public enum Sex {
+    MALE,
+    FEMALE
+}

--- a/src/main/java/team/silvertown/masil/user/domain/User.java
+++ b/src/main/java/team/silvertown/masil/user/domain/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.sql.Date;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,6 +19,8 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class User extends BaseEntity {
 
@@ -52,7 +55,7 @@ public class User extends BaseEntity {
     private Integer totalCount;
 
     @Column(name = "is_public")
-    private boolean isPublic;
+    private Boolean isPublic;
 
     @Column(name = "is_allowing_notification")
     private boolean isAllowingNotification;
@@ -63,32 +66,5 @@ public class User extends BaseEntity {
 
     @Column(name = "social_id", length = 50)
     private String socialId;
-
-    @Builder
-    private User(
-        String nickname,
-        Sex sex,
-        Date birthDate,
-        Integer height,
-        Integer weight,
-        ExerciseIntensity exerciseIntensity,
-        Integer totalDistance,
-        Integer totalCount,
-        Provider provider,
-        String socialId
-    ) {
-        this.nickname = nickname;
-        this.sex = sex;
-        this.birthDate = birthDate;
-        this.height = height;
-        this.weight = weight;
-        this.exerciseIntensity = exerciseIntensity;
-        this.totalDistance = totalDistance;
-        this.totalCount = totalCount;
-        this.provider = provider;
-        this.socialId = socialId;
-        this.isPublic = true;
-        this.isAllowingNotification = true;
-    }
 
 }

--- a/src/main/java/team/silvertown/masil/user/domain/User.java
+++ b/src/main/java/team/silvertown/masil/user/domain/User.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.sql.Date;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.silvertown.masil.common.BaseEntity;
@@ -17,6 +19,8 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class User extends BaseEntity {
 

--- a/src/main/java/team/silvertown/masil/user/domain/User.java
+++ b/src/main/java/team/silvertown/masil/user/domain/User.java
@@ -1,0 +1,66 @@
+package team.silvertown.masil.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.sql.Date;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.silvertown.masil.common.BaseEntity;
+
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nickname", unique = true)
+    private String nickname;
+
+    @Column(name = "sex", columnDefinition = "CHAR(8)")
+    @Enumerated(EnumType.STRING)
+    private Sex sex;
+
+    @Column(name = "birth_date")
+    private Date birthDate;
+
+    @Column(name = "height")
+    private Integer height;
+
+    @Column(name = "weight")
+    private Integer weight;
+
+    @Column(name = "exercise_intensity", columnDefinition = "VARCHAR(15)")
+    @Enumerated(EnumType.STRING)
+    private ExerciseIntensity exerciseIntensity;
+
+    @Column(name = "total_distance")
+    private Integer totalDistance;
+
+    @Column(name = "total_count")
+    private Integer totalCount;
+
+    @Column(name = "is_public", columnDefinition = "DEFAULT 1")
+    private boolean isPublic = true;
+
+    @Column(name = "is_allowing_notification", columnDefinition = "DEFAULT 1")
+    private boolean isAllowingNotification = true;
+
+    @Column(name = "provider", columnDefinition = "VARCHAR(20)")
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Column(name = "social_id", length = 50)
+    private String socialId;
+
+}

--- a/src/main/java/team/silvertown/masil/user/domain/User.java
+++ b/src/main/java/team/silvertown/masil/user/domain/User.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.sql.Date;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,8 +18,6 @@ import team.silvertown.masil.common.BaseEntity;
 @Entity
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 @Getter
 public class User extends BaseEntity {
 
@@ -54,11 +51,11 @@ public class User extends BaseEntity {
     @Column(name = "total_count")
     private Integer totalCount;
 
-    @Column(name = "is_public", columnDefinition = "DEFAULT 1")
-    private boolean isPublic = true;
+    @Column(name = "is_public")
+    private boolean isPublic;
 
-    @Column(name = "is_allowing_notification", columnDefinition = "DEFAULT 1")
-    private boolean isAllowingNotification = true;
+    @Column(name = "is_allowing_notification")
+    private boolean isAllowingNotification;
 
     @Column(name = "provider", columnDefinition = "VARCHAR(20)")
     @Enumerated(EnumType.STRING)
@@ -66,5 +63,32 @@ public class User extends BaseEntity {
 
     @Column(name = "social_id", length = 50)
     private String socialId;
+
+    @Builder
+    private User(
+        String nickname,
+        Sex sex,
+        Date birthDate,
+        Integer height,
+        Integer weight,
+        ExerciseIntensity exerciseIntensity,
+        Integer totalDistance,
+        Integer totalCount,
+        Provider provider,
+        String socialId
+    ) {
+        this.nickname = nickname;
+        this.sex = sex;
+        this.birthDate = birthDate;
+        this.height = height;
+        this.weight = weight;
+        this.exerciseIntensity = exerciseIntensity;
+        this.totalDistance = totalDistance;
+        this.totalCount = totalCount;
+        this.provider = provider;
+        this.socialId = socialId;
+        this.isPublic = true;
+        this.isAllowingNotification = true;
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/user/domain/UserAuthority.java
+++ b/src/main/java/team/silvertown/masil/user/domain/UserAuthority.java
@@ -12,7 +12,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,9 +21,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 @Entity
 @Table(name = "user_authorities")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
-@Getter()
+@Getter
 public class UserAuthority {
 
     private static final String ROLE_PREFIX = "ROLE_";
@@ -40,6 +37,12 @@ public class UserAuthority {
     @Column(name = "authority", columnDefinition = "VARCHAR(20)")
     @Enumerated(EnumType.STRING)
     private Authority authority;
+
+    @Builder
+    private UserAuthority(User user, Authority authority) {
+        this.user = user;
+        this.authority = authority;
+    }
 
     public GrantedAuthority getAuthority() {
         return new SimpleGrantedAuthority(ROLE_PREFIX + authority.name());

--- a/src/main/java/team/silvertown/masil/user/domain/UserAuthority.java
+++ b/src/main/java/team/silvertown/masil/user/domain/UserAuthority.java
@@ -1,0 +1,39 @@
+package team.silvertown.masil.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@Entity
+@Table(name = "user_authorities")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class UserAuthority {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    @Column(name = "authority", length = 20)
+    private String authority;
+
+    public GrantedAuthority getAuthority() {
+        return new SimpleGrantedAuthority(this.authority);
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/user/domain/UserAuthority.java
+++ b/src/main/java/team/silvertown/masil/user/domain/UserAuthority.java
@@ -2,6 +2,8 @@ package team.silvertown.masil.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -22,8 +24,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@Getter
+@Getter()
 public class UserAuthority {
+
+    private static final String ROLE_PREFIX = "ROLE_";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,11 +37,12 @@ public class UserAuthority {
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
 
-    @Column(name = "authority", length = 20)
-    private String authority;
+    @Column(name = "authority", columnDefinition = "VARCHAR(20)")
+    @Enumerated(EnumType.STRING)
+    private Authority authority;
 
     public GrantedAuthority getAuthority() {
-        return new SimpleGrantedAuthority(this.authority);
+        return new SimpleGrantedAuthority(ROLE_PREFIX + authority.name());
     }
 
 }

--- a/src/main/java/team/silvertown/masil/user/domain/UserAuthority.java
+++ b/src/main/java/team/silvertown/masil/user/domain/UserAuthority.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
@@ -18,6 +20,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 @Entity
 @Table(name = "user_authorities")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Getter
 public class UserAuthority {
 

--- a/src/main/resources/db/migration/V1__schema.sql
+++ b/src/main/resources/db/migration/V1__schema.sql
@@ -35,7 +35,7 @@ CREATE TABLE masils
     user_id        BIGINT        NOT NULL,
     post_id        BIGINT        NULL,
     address_depth1 VARCHAR(20)   NOT NULL,
-    address_depth2 VARCHAR(20)   NOT NULL,
+    address_depth2 VARCHAR(20),
     address_depth3 VARCHAR(20)   NOT NULL,
     path           LINESTRING    NOT NULL,
     title          VARCHAR(30)   NOT NULL,

--- a/src/test/java/team/silvertown/masil/masil/domain/MasilPinTest.java
+++ b/src/test/java/team/silvertown/masil/masil/domain/MasilPinTest.java
@@ -1,0 +1,26 @@
+package team.silvertown.masil.masil.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import team.silvertown.masil.masil.domain.MasilPin.MasilPinBuilder;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MasilPinTest {
+
+    @Test
+    void 마실_핀_생성을_할_수_있다() {
+        // given
+        MasilPinBuilder builder = MasilPin.builder();
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatNoException().isThrownBy(create);
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/masil/domain/MasilTest.java
+++ b/src/test/java/team/silvertown/masil/masil/domain/MasilTest.java
@@ -1,0 +1,26 @@
+package team.silvertown.masil.masil.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import team.silvertown.masil.masil.domain.Masil.MasilBuilder;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MasilTest {
+
+    @Test
+    void 마실_생성을_할_수_있다() {
+        // given
+        MasilBuilder builder = Masil.builder();
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatNoException().isThrownBy(create);
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/post/domain/PostPinTest.java
+++ b/src/test/java/team/silvertown/masil/post/domain/PostPinTest.java
@@ -1,0 +1,26 @@
+package team.silvertown.masil.post.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import team.silvertown.masil.post.domain.PostPin.PostPinBuilder;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PostPinTest {
+
+    @Test
+    void 포스트_핀_생성을_할_수_있다() {
+        // given
+        PostPinBuilder builder = PostPin.builder();
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatNoException().isThrownBy(create);
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/post/domain/PostTest.java
+++ b/src/test/java/team/silvertown/masil/post/domain/PostTest.java
@@ -1,0 +1,26 @@
+package team.silvertown.masil.post.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import team.silvertown.masil.post.domain.Post.PostBuilder;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PostTest {
+
+    @Test
+    void 포스트_생성을_할_수_있다() {
+        // given
+        PostBuilder builder = Post.builder();
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatNoException().isThrownBy(create);
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/user/domain/UserAuthorityTest.java
+++ b/src/test/java/team/silvertown/masil/user/domain/UserAuthorityTest.java
@@ -1,0 +1,44 @@
+package team.silvertown.masil.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import team.silvertown.masil.user.domain.UserAuthority.UserAuthorityBuilder;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class UserAuthorityTest {
+
+    @Test
+    void 유저_권한을_생성할_수_있다() {
+        // given
+        UserAuthorityBuilder builder = UserAuthority.builder();
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatNoException().isThrownBy(create);
+    }
+
+    @Test
+    void 유저_권한을_조회한다() {
+        // given
+        UserAuthority authority = UserAuthority.builder()
+            .authority(Authority.RESTRICTED)
+            .build();
+
+        // when
+        GrantedAuthority grantedAuthority = authority.getAuthority();
+
+        // then
+        String roleAuthority = grantedAuthority.getAuthority();
+
+        assertThat(roleAuthority).isEqualTo("ROLE_RESTRICTED");
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/user/domain/UserTest.java
+++ b/src/test/java/team/silvertown/masil/user/domain/UserTest.java
@@ -1,0 +1,26 @@
+package team.silvertown.masil.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import team.silvertown.masil.user.domain.User.UserBuilder;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class UserTest {
+
+    @Test
+    void 유저_생성을_할_수_있다() {
+        // given
+        UserBuilder builder = User.builder();
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatNoException().isThrownBy(create);
+    }
+
+}


### PR DESCRIPTION
* Resolves #10 

## 반영 사항
### `Spring Boot Security` 추가
  * `GrantedAuthority` 사용
  * `WebSecurityConfig`: 불필요한 필터 비활성화
     api 테스트 간단하게 진행해보다가 security를 추가해서 필요했는데 한 김에 PR에 추가했습니다!
### 엔티티 작성
* `schema.sql`을 기반으로 작성
* 기본 단방향 매핑 적용
* 빌더 적용
* Geometry 적용을 위한 `hibernate-spatial` 의존성 추가
* **`BaseEntity`**
  * `OffsetDateTime` 호환을 위한 `@CreationTimestamp`, `@UpdateTimestamp` 사용
  * `TimeZoneStorage`: Hibernate 6.2부터 기본 타임존이 UTC -> `NORMALIZE`로 DB 타임존 반영
* **`User`**
  * 임의 작성
* **`UserAuthority`**
  * `Authority`를 enum으로 관리
  * `ANONYMOUS`는 Spring Security가 알아서 달아주니 뺐습니다
  * `ROLE_PREFIX` 상수: 추가 prefix 고려 (ex. `SCOPE_`)
  * `getAuthority` 구현: `GrantedAuthority` 반환 (ex. `ROLE_RESTRICTED`)
* **`Masil`**
  * 열심히 함.
  * `LineString` 반영
* **`MasilPin`**
  * `Point`반영
* **`Post`**
  * `Masil`과 비슷
* **`PostPin`**
  * `MasilPin`과 비슷

## 예상 QnA
**Q. 빌더는 왜 `@AllArgsConstructor` 안 썼죠?**
A. 디폴트 값이 반영이 안됩니다. `User`와  `Post`는 그런 이유로 생성자 위에 썼고, 나머지도 일관적으로 가져가려고 그랬습니다. 혹시 나중에 디폴트 값이 추가되는 엔티티가 있을 수도 있으니까..

**Q. 테스트 왜 이렇게 부실하게 짰죠?**
A. 죄송합니다. 안 하려고 했는데 자코코 통과하려고 썼습니다. 임시이니 나중에 필요한 부분 추가해주세요..

**Q. 도메인 패키지를 왜 포스트, 마실, 유저만 썼죠?**
A. 비슷하다고 생각해서 그렇게 했습니다. 핀은 포스트, 마실이 있어야 존재하고, 유저 권한도 유저가 있어야 하니까..

**Q. 왜 맘대로 세큐리티 추가하고 Authority 저렇게 한거죠? 합의된건가요?**
A. 죄송합니다. 임시로 저렇게 했습니다. 계속 보다보니 DB에 굳이 `ROLE_`이 붙어서 들어갈 필요가 없을 것 같았습니다. Spring Security에서 제공하는 JWT 라이브러리를 쓰면 `SCOPE_`를 authority로 읽는데 만약 JWT를 Spring Security꺼로 쓴다면 확장할 수도 있지 않을까 했습니다. 참고할 수 있겠다만 생각해주시고 맘대로 수정해주세요. 전 선호하는 방향은 없습니다..

또 고민 됐던 점이 있었는데 그새 까먹어버렸네요..질문 주세요!