### PR TITLE
🚀 마실 도메인 생성 로직 및 검증 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 
     // spatial
     implementation 'org.hibernate.orm:hibernate-spatial'
+
+    // faker
+    implementation 'net.datafaker:datafaker:2.1.0'
 }
 
 test {

--- a/src/main/java/team/silvertown/masil/common/map/Address.java
+++ b/src/main/java/team/silvertown/masil/common/map/Address.java
@@ -1,5 +1,6 @@
 package team.silvertown.masil.common.map;
 
+import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -30,7 +31,7 @@ public class Address {
         this.depth1 = depth1;
         this.depth2 = depth2;
 
-        if (!depth4.isBlank()) {
+        if (StringUtils.isNotBlank(depth4)) {
             depth3 += " " + depth4;
         }
 

--- a/src/main/java/team/silvertown/masil/common/map/Address.java
+++ b/src/main/java/team/silvertown/masil/common/map/Address.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.silvertown.masil.common.exception.BadRequestException;
 import team.silvertown.masil.common.validator.Validator;
 
 @Embeddable
@@ -24,9 +23,9 @@ public class Address {
     private String depth3;
 
     public Address(String depth1, String depth2, String depth3, String depth4) {
-        Validator.notBlank(depth1, () -> new BadRequestException(MapErrorCode.BLANK_DEPTH1));
-        Validator.notNull(depth2, () -> new BadRequestException(MapErrorCode.NULL_DEPTH2));
-        Validator.notBlank(depth3, () -> new BadRequestException(MapErrorCode.BLANK_DEPTH3));
+        Validator.notBlank(depth1, MapErrorCode.BLANK_DEPTH1);
+        Validator.notNull(depth2, MapErrorCode.NULL_DEPTH2);
+        Validator.notBlank(depth3, MapErrorCode.BLANK_DEPTH3);
 
         this.depth1 = depth1;
         this.depth2 = depth2;

--- a/src/main/java/team/silvertown/masil/common/map/Address.java
+++ b/src/main/java/team/silvertown/masil/common/map/Address.java
@@ -2,9 +2,14 @@ package team.silvertown.masil.common.map;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.common.validator.Validator;
 
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Address {
 
@@ -16,5 +21,20 @@ public class Address {
 
     @Column(name = "address_depth3", length = 20, nullable = false)
     private String depth3;
+
+    public Address(String depth1, String depth2, String depth3, String depth4) {
+        Validator.notBlank(depth1, () -> new BadRequestException(MapErrorCode.BLANK_DEPTH1));
+        Validator.notNull(depth2, () -> new BadRequestException(MapErrorCode.NULL_DEPTH2));
+        Validator.notBlank(depth3, () -> new BadRequestException(MapErrorCode.BLANK_DEPTH3));
+
+        this.depth1 = depth1;
+        this.depth2 = depth2;
+
+        if (!depth4.isBlank()) {
+            depth3 += " " + depth4;
+        }
+
+        this.depth3 = depth3;
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/common/map/KakaoPointMapper.java
+++ b/src/main/java/team/silvertown/masil/common/map/KakaoPointMapper.java
@@ -1,27 +1,35 @@
 package team.silvertown.masil.common.map;
 
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
+import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.common.validator.Validator;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class KakaoPointMapper {
 
+    private static final int MIN_POINT_NUM = 2;
     private static final WKTReader wktReader = new WKTReader();
 
-    private KakaoPointMapper() {
-    }
-
     public static Point mapToPoint(KakaoPoint point) {
+        Validator.notNull(point, () -> new BadRequestException(MapErrorCode.NULL_KAKAO_POINT));
+
         try {
             return (Point) wktReader.read("POINT(" + point.toRawString() + ")");
         } catch (ParseException e) {
-            throw new RuntimeException("Wrong Point format");
+            throw new RuntimeException("Point 변환을 실패했습니다");
         }
     }
 
     public static LineString mapToLineString(List<KakaoPoint> path) {
+        Validator.throwIf(path.size() < MIN_POINT_NUM,
+            () -> new BadRequestException(MapErrorCode.INSUFFICIENT_PATH_POINTS));
+
         StringBuilder stringBuilder = new StringBuilder("LINESTRING(");
 
         path.forEach(point -> stringBuilder.append(point.toRawString())
@@ -31,7 +39,7 @@ public final class KakaoPointMapper {
         try {
             return (LineString) wktReader.read(stringBuilder.toString());
         } catch (ParseException e) {
-            throw new RuntimeException("Wrong LineString format");
+            throw new RuntimeException("LineString 변환을 실패했습니다");
         }
     }
 

--- a/src/main/java/team/silvertown/masil/common/map/MapErrorCode.java
+++ b/src/main/java/team/silvertown/masil/common/map/MapErrorCode.java
@@ -7,7 +7,8 @@ public enum MapErrorCode implements ErrorCode {
     NULL_DEPTH2(20011001, "지역 2 Depth는 Null이 될 수 없습니다"),
     BLANK_DEPTH3(20011002, "지역 3 Depth가 입력되지 않았습니다"),
 
-    NULL_KAKAO_POINT(20016001, "입력된 포인트가 NULL이 될 수 없습니다"),
+    NULL_KAKAO_POINT(20016000, "입력된 포인트가 NULL이 될 수 없습니다"),
+    NULL_PATH(20016001, "입력된 경로가 NULL이 될 수 없습니다"),
     INSUFFICIENT_PATH_POINTS(20016002, "포인트 수가 부족해 경로를 생성할 수 없습니다");
 
     private final int code;

--- a/src/main/java/team/silvertown/masil/common/map/MapErrorCode.java
+++ b/src/main/java/team/silvertown/masil/common/map/MapErrorCode.java
@@ -1,0 +1,30 @@
+package team.silvertown.masil.common.map;
+
+import team.silvertown.masil.common.exception.ErrorCode;
+
+public enum MapErrorCode implements ErrorCode {
+    BLANK_DEPTH1(20011000, "지역 1 Depth가 입력되지 않았습니다"),
+    NULL_DEPTH2(20011001, "지역 2 Depth는 Null이 될 수 없습니다"),
+    BLANK_DEPTH3(20011002, "지역 3 Depth가 입력되지 않았습니다"),
+
+    NULL_KAKAO_POINT(20016001, "입력된 포인트가 NULL이 될 수 없습니다"),
+    INSUFFICIENT_PATH_POINTS(20016002, "포인트 수가 부족해 경로를 생성할 수 없습니다");
+
+    private final int code;
+    private final String message;
+
+    MapErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/team/silvertown/masil/common/validator/Validator.java
+++ b/src/main/java/team/silvertown/masil/common/validator/Validator.java
@@ -5,6 +5,8 @@ import java.util.function.Supplier;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
+import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.common.exception.ErrorCode;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Validator {
@@ -15,31 +17,26 @@ public class Validator {
         }
     }
 
-    public static void notNull(Object object, Supplier<RuntimeException> exceptionSupplier) {
-        throwIf(Objects.isNull(object), exceptionSupplier);
+    public static void notNull(Object object, ErrorCode errorCode) {
+        throwIf(Objects.isNull(object), supplyBadRequest(errorCode));
     }
 
-    public static void notBlank(String string, Supplier<RuntimeException> exceptionSupplier) {
-        notNull(string, exceptionSupplier);
-        throwIf(string.isBlank(), exceptionSupplier);
+    public static void notBlank(String string, ErrorCode errorCode) {
+        notNull(string, errorCode);
+        throwIf(string.isBlank(), supplyBadRequest(errorCode));
     }
 
-    public static void notOver(int size, int max, Supplier<RuntimeException> exceptionSupplier) {
-        throwIf(size > max, exceptionSupplier);
+    public static void notOver(int size, int max, ErrorCode errorCode) {
+        throwIf(size > max, supplyBadRequest(errorCode));
     }
 
-    public static void notUnder(int size, int min, Supplier<RuntimeException> exceptionSupplier) {
-        throwIf(size < min, exceptionSupplier);
+    public static void notUnder(int size, int min, ErrorCode errorCode) {
+        throwIf(size < min, supplyBadRequest(errorCode));
     }
 
-    public static void range(
-        int size,
-        int min,
-        int max,
-        Supplier<RuntimeException> exceptionSupplier
-    ) {
-        notOver(size, max, exceptionSupplier);
-        notUnder(size, min, exceptionSupplier);
+    public static void range(int size, int min, int max, ErrorCode errorCode) {
+        notOver(size, max, errorCode);
+        notUnder(size, min, errorCode);
     }
 
     public static void notMatching(
@@ -47,10 +44,14 @@ public class Validator {
         String string,
         @Nullable
         String pattern,
-        Supplier<RuntimeException> exceptionSupplier
+        ErrorCode errorCode
     ) {
-        notNull(string, exceptionSupplier);
-        throwIf(!string.matches(Objects.requireNonNull(pattern)), exceptionSupplier);
+        notNull(string, errorCode);
+        throwIf(!string.matches(Objects.requireNonNull(pattern)), supplyBadRequest(errorCode));
+    }
+
+    private static Supplier<RuntimeException> supplyBadRequest(ErrorCode errorCode) {
+        return () -> new BadRequestException(errorCode);
     }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -12,20 +12,21 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.TimeZoneStorage;
+import org.hibernate.annotations.TimeZoneStorageType;
 import org.locationtech.jts.geom.LineString;
 import team.silvertown.masil.common.BaseEntity;
 import team.silvertown.masil.common.map.Address;
+import team.silvertown.masil.masil.exception.MasilErrorCode;
+import team.silvertown.masil.masil.validator.MasilValidator;
 import team.silvertown.masil.user.domain.User;
 
 @Entity
 @Table(name = "masils")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 @Getter
 public class Masil extends BaseEntity {
 
@@ -46,8 +47,8 @@ public class Masil extends BaseEntity {
     @Column(name = "path", nullable = false)
     private LineString path;
 
-    @Column(name = "title", nullable = false, length = 30)
-    private String title;
+    @Embedded
+    private MasilTitle title;
 
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
@@ -62,6 +63,40 @@ public class Masil extends BaseEntity {
     private Integer totalTime;
 
     @Column(name = "started_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
+    @TimeZoneStorage(TimeZoneStorageType.NORMALIZE)
     private OffsetDateTime startedAt;
+
+    @Builder
+    private Masil(
+        User user,
+        Long postId,
+        String depth1,
+        String depth2,
+        String depth3,
+        String depth4,
+        LineString path,
+        String title,
+        String content,
+        String thumbnailUrl,
+        Integer distance,
+        Integer totalTime,
+        OffsetDateTime startedAt
+    ) {
+        MasilValidator.notNull(user, MasilErrorCode.NULL_USER);
+        MasilValidator.validateUrl(thumbnailUrl);
+        MasilValidator.notNull(distance, MasilErrorCode.NULL_DISTANCE);
+        MasilValidator.notNull(totalTime, MasilErrorCode.NULL_TOTAL_TIME);
+
+        this.user = user;
+        this.postId = postId;
+        this.address = new Address(depth1, depth2, depth3, depth4);
+        this.path = path;
+        this.title = new MasilTitle(title);
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.distance = distance;
+        this.totalTime = totalTime;
+        this.startedAt = startedAt;
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
@@ -10,18 +10,17 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import team.silvertown.masil.common.BaseEntity;
+import team.silvertown.masil.masil.exception.MasilErrorCode;
+import team.silvertown.masil.masil.validator.MasilValidator;
 
 @Entity
 @Table(name = "masil_pins")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 @Getter
 public class MasilPin extends BaseEntity {
 
@@ -44,5 +43,17 @@ public class MasilPin extends BaseEntity {
 
     @Column(name = "thumbnail_url", length = 1024)
     private String thumbnailUrl;
+
+    @Builder
+    private MasilPin(Masil masil, Long userId, Point point, String content, String thumbnailUrl) {
+        MasilValidator.notNull(masil, MasilErrorCode.NULL_MASIL);
+        MasilValidator.validateUrl(thumbnailUrl);
+
+        this.masil = masil;
+        this.userId = userId;
+        this.point = point;
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/domain/MasilTitle.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/MasilTitle.java
@@ -1,0 +1,36 @@
+package team.silvertown.masil.masil.domain;
+
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.silvertown.masil.masil.validator.MasilValidator;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MasilTitle {
+
+    private static final String DEFAULT_TITLE_SUFFIX = " 산책 기록";
+
+    @Column(name = "title", nullable = false, length = 30)
+    private String title;
+
+    public MasilTitle(String title) {
+        MasilValidator.validateTitle(title);
+
+        this.title = StringUtils.isNotBlank(title) ? title : generateDefaultTitle();
+    }
+
+    private String generateDefaultTitle() {
+        LocalDate today = OffsetDateTime.now()
+            .toLocalDate();
+
+        return today.toString() + DEFAULT_TITLE_SUFFIX;
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/exception/MasilErrorCode.java
+++ b/src/main/java/team/silvertown/masil/masil/exception/MasilErrorCode.java
@@ -1,0 +1,35 @@
+package team.silvertown.masil.masil.exception;
+
+import team.silvertown.masil.common.exception.ErrorCode;
+
+public enum MasilErrorCode implements ErrorCode {
+    NULL_TITLE(20111000, "제목이 입력되지 않았습니다"),
+    TITLE_TOO_LONG(20111001, "제목 길이가 제한을 초과했습니다"),
+    THUMBNAIL_URL_TOO_LONG(20111002, "썸네일 URL 주소 길이가 제한을 초과했습니다"),
+
+    NULL_DISTANCE(20112000, "산책 거리가 NULL이 될 수 없습니다"),
+    NULL_TOTAL_TIME(20112001, "산책 시간이 NULL이 될 수 없습니다"),
+
+    NULL_MASIL(20130000, "핀의 마실 기록을 확인할 수 없습니다"),
+
+    NULL_USER(20190000, "마실 기록 사용자를 확인할 수 없습니다"),
+    USER_NOT_FOUND(20190400, "마실 기록 사용자가 존재하지 않습니다");
+
+    private final int code;
+    private final String message;
+
+    MasilErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/team/silvertown/masil/masil/validator/MasilValidator.java
+++ b/src/main/java/team/silvertown/masil/masil/validator/MasilValidator.java
@@ -1,0 +1,27 @@
+package team.silvertown.masil.masil.validator;
+
+import io.micrometer.common.util.StringUtils;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import team.silvertown.masil.common.validator.Validator;
+import team.silvertown.masil.masil.exception.MasilErrorCode;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MasilValidator extends Validator {
+
+    private static final int MAX_TITLE_LENGTH = 30;
+    private static final int MAX_URL_LENGTH = 1024;
+
+    public static void validateTitle(String title) {
+        if (StringUtils.isNotBlank(title)) {
+            notOver(title.length(), MAX_TITLE_LENGTH, MasilErrorCode.TITLE_TOO_LONG);
+        }
+    }
+
+    public static void validateUrl(String url) {
+        if (StringUtils.isNotBlank(url)) {
+            notOver(url.length(), MAX_URL_LENGTH, MasilErrorCode.THUMBNAIL_URL_TOO_LONG);
+        }
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/common/map/AddressTest.java
+++ b/src/test/java/team/silvertown/masil/common/map/AddressTest.java
@@ -1,0 +1,89 @@
+package team.silvertown.masil.common.map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.Locale;
+import net.datafaker.Faker;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import team.silvertown.masil.common.exception.BadRequestException;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class AddressTest {
+
+    static final Faker faker = new Faker(Locale.KOREA);
+
+    String addressDepth1;
+    String addressDepth2;
+    String addressDepth3;
+
+    @BeforeEach
+    void setUp() {
+        addressDepth1 = faker.address()
+            .state();
+        addressDepth2 = faker.address()
+            .city();
+        addressDepth3 = faker.address()
+            .streetName();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "땡땡리"})
+    void 주소_생성을_성공한다(String addressDepth4) {
+        // given
+
+        // when
+        Address address = new Address(addressDepth1, addressDepth2, addressDepth3, addressDepth4);
+
+        // then
+        assertThat(address.getDepth3()).contains(addressDepth4.strip());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 지역_Depth_1이_빈_값이면_주소_생성을_실패한다(String blankDepth1) {
+        // given
+
+        // when
+        ThrowingCallable create = () -> new Address(blankDepth1, addressDepth2, addressDepth3, "");
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MapErrorCode.BLANK_DEPTH1.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    void 지역_Depth_2가_NULL_값이면_주소_생성을_실패한다(String nullDepth2) {
+        // given
+
+        // when
+        ThrowingCallable create = () -> new Address(addressDepth1, nullDepth2, addressDepth3, "");
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MapErrorCode.NULL_DEPTH2.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 지역_Depth_3이_빈_값이면_주소_생성을_실패한다(String blankDepth3) {
+        // given
+
+        // when
+        ThrowingCallable create = () -> new Address(addressDepth1, addressDepth2, blankDepth3, "");
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MapErrorCode.BLANK_DEPTH3.getMessage());
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/common/map/KakaoPointMapperTest.java
+++ b/src/test/java/team/silvertown/masil/common/map/KakaoPointMapperTest.java
@@ -1,0 +1,101 @@
+package team.silvertown.masil.common.map;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import team.silvertown.masil.common.exception.BadRequestException;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class KakaoPointMapperTest {
+
+    double dongAnLat = 37.4004;
+    double dongAnLng = 126.9555;
+
+    @Test
+    void Point_변환을_성공한다() {
+        // given
+        KakaoPoint point = new KakaoPoint(dongAnLat, dongAnLng);
+
+        // when
+        ThrowingCallable map = () -> KakaoPointMapper.mapToPoint(point);
+
+        // then
+        assertThatNoException().isThrownBy(map);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    void 카카오_포인트가_NULL이면_Point_변환을_실패한다(KakaoPoint point) {
+        // given
+
+        // when
+        ThrowingCallable map = () -> KakaoPointMapper.mapToPoint(point);
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(map)
+            .withMessage(MapErrorCode.NULL_KAKAO_POINT.getMessage());
+    }
+
+    @Test
+    void Line_String_변환을_성공한다() {
+        // given
+        List<KakaoPoint> path = createPath(10);
+
+        // when
+        ThrowingCallable map = () -> KakaoPointMapper.mapToLineString(path);
+
+        // then
+        assertThatNoException().isThrownBy(map);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    void 경로가_NULL이면_Line_String_변환을_실패한다(List<KakaoPoint> path) {
+        // given
+
+        // when
+        ThrowingCallable map = () -> KakaoPointMapper.mapToLineString(path);
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(map)
+            .withMessage(MapErrorCode.NULL_KAKAO_POINT.getMessage());
+    }
+
+    @Test
+    void 경로의_포인트가_2개_이하면_Line_String_변환을_실패한다() {
+        // given
+        List<KakaoPoint> path = createPath(2);
+
+        // when
+        ThrowingCallable create = () -> KakaoPointMapper.mapToLineString(path);
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MapErrorCode.INSUFFICIENT_PATH_POINTS.getMessage());
+    }
+
+    List<KakaoPoint> createPath(int size) {
+        List<KakaoPoint> path = new ArrayList<>();
+        double appender = 0.002;
+
+        for (int i = 0; i < size; i++) {
+            double lat = dongAnLat + appender * i;
+            double lng = dongAnLng + appender * i;
+
+            KakaoPoint point = new KakaoPoint(lat, lng);
+
+            path.add(point);
+        }
+
+        return path;
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/masil/domain/MasilPinTest.java
+++ b/src/test/java/team/silvertown/masil/masil/domain/MasilPinTest.java
@@ -1,26 +1,176 @@
 package team.silvertown.masil.masil.domain;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import net.datafaker.Faker;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.common.map.KakaoPoint;
+import team.silvertown.masil.common.map.KakaoPointMapper;
 import team.silvertown.masil.masil.domain.MasilPin.MasilPinBuilder;
+import team.silvertown.masil.masil.exception.MasilErrorCode;
+import team.silvertown.masil.user.domain.ExerciseIntensity;
+import team.silvertown.masil.user.domain.Provider;
+import team.silvertown.masil.user.domain.Sex;
+import team.silvertown.masil.user.domain.User;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class MasilPinTest {
 
+    static final Faker faker = new Faker(Locale.KOREA);
+
+    Masil masil;
+    Point point;
+    long userId;
+
+    @BeforeEach
+    void setUp() {
+        masil = createMasil();
+        point = createPoint();
+        userId = faker.random()
+            .nextLong(Long.MAX_VALUE);
+    }
+
     @Test
     void 마실_핀_생성을_할_수_있다() {
         // given
-        MasilPinBuilder builder = MasilPin.builder();
+        MasilPinBuilder builder = MasilPin.builder()
+            .userId(userId)
+            .masil(masil)
+            .point(point);
 
         // when
         ThrowingCallable create = builder::build;
 
         // then
         assertThatNoException().isThrownBy(create);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    void 마실이_확인이_안되면_마실_핀_생성을_실패한다(Masil nullMasil) {
+        // given
+        MasilPinBuilder builder = MasilPin.builder()
+            .userId(userId)
+            .point(point)
+            .masil(nullMasil);
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MasilErrorCode.NULL_MASIL.getMessage());
+    }
+
+    @Test
+    void 썸네일_Url이_1024자를_넘으면_마실_핀_생성을_실패한다() {
+        // given
+        String thumbnailUrl = faker.lorem()
+            .sentence(1020) + faker.internet()
+            .domainName();
+        MasilPinBuilder builder = MasilPin.builder()
+            .masil(masil)
+            .userId(userId)
+            .point(point)
+            .thumbnailUrl(thumbnailUrl);
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MasilErrorCode.THUMBNAIL_URL_TOO_LONG.getMessage());
+    }
+
+    Masil createMasil() {
+        User user = createUser();
+        String addressDepth1 = faker.address()
+            .state();
+        String addressDepth2 = faker.address()
+            .city();
+        String addressDepth3 = faker.address()
+            .streetName();
+        LineString path = createLineString(10);
+        String title = faker.book()
+            .title();
+        int totalTime = faker.number()
+            .numberBetween(10, 70);
+
+        return Masil.builder()
+            .user(user)
+            .depth1(addressDepth1)
+            .depth2(addressDepth2)
+            .depth3(addressDepth3)
+            .path(path)
+            .title(title)
+            .distance((int) path.getLength())
+            .totalTime(totalTime)
+            .build();
+    }
+
+    User createUser() {
+        String nickname = faker.funnyName()
+            .name();
+        LocalDate birthDate = faker.date()
+            .birthdayLocalDate(20, 40);
+        int height = faker.number()
+            .numberBetween(170, 190);
+        int weight = faker.number()
+            .numberBetween(60, 90);
+        long socialId = faker.random()
+            .nextLong(Long.MAX_VALUE);
+
+        return User.builder()
+            .nickname(nickname)
+            .exerciseIntensity(ExerciseIntensity.MIDDLE)
+            .sex(Sex.MALE)
+            .birthDate(Date.valueOf(birthDate))
+            .height(height)
+            .weight(weight)
+            .provider(Provider.KAKAO)
+            .socialId(String.valueOf(socialId))
+            .build();
+    }
+
+    Point createPoint() {
+        double dongAnLat = 37.4004;
+        double dongAnLng = 126.9555;
+        KakaoPoint point = new KakaoPoint(dongAnLat, dongAnLng);
+
+        return KakaoPointMapper.mapToPoint(point);
+    }
+
+    LineString createLineString(int size) {
+        List<KakaoPoint> path = new ArrayList<>();
+        double dongAnLat = 37.4004;
+        double dongAnLng = 126.9555;
+        double appender = 0.002;
+
+        for (int i = 0; i < size; i++) {
+            dongAnLat += appender * i;
+            dongAnLng += appender * i;
+
+            KakaoPoint point = new KakaoPoint(dongAnLat, dongAnLng);
+
+            path.add(point);
+        }
+
+        return KakaoPointMapper.mapToLineString(path);
     }
 
 }

--- a/src/test/java/team/silvertown/masil/masil/domain/MasilTest.java
+++ b/src/test/java/team/silvertown/masil/masil/domain/MasilTest.java
@@ -1,26 +1,210 @@
 package team.silvertown.masil.masil.domain;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import net.datafaker.Faker;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.LineString;
+import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.common.map.KakaoPoint;
+import team.silvertown.masil.common.map.KakaoPointMapper;
 import team.silvertown.masil.masil.domain.Masil.MasilBuilder;
+import team.silvertown.masil.masil.exception.MasilErrorCode;
+import team.silvertown.masil.user.domain.ExerciseIntensity;
+import team.silvertown.masil.user.domain.Provider;
+import team.silvertown.masil.user.domain.Sex;
+import team.silvertown.masil.user.domain.User;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class MasilTest {
 
+    static final Faker faker = new Faker(Locale.KOREA);
+
+    User user;
+    String addressDepth1;
+    String addressDepth2;
+    String addressDepth3;
+    LineString path;
+    String title;
+    int totalTime;
+
+    @BeforeEach
+    void setUp() {
+        user = createUser();
+        addressDepth1 = faker.address()
+            .state();
+        addressDepth2 = faker.address()
+            .city();
+        addressDepth3 = faker.address()
+            .streetName();
+        path = createLineString(10);
+        title = faker.book()
+            .title();
+        totalTime = faker.number()
+            .numberBetween(10, 70);
+    }
+
     @Test
     void 마실_생성을_할_수_있다() {
         // given
-        MasilBuilder builder = Masil.builder();
+        MasilBuilder builder = Masil.builder()
+            .user(user)
+            .depth1(addressDepth1)
+            .depth2(addressDepth2)
+            .depth3(addressDepth3)
+            .path(path)
+            .title(title)
+            .distance((int) path.getLength())
+            .totalTime(totalTime)
+            .startedAt(OffsetDateTime.now());
 
         // when
         ThrowingCallable create = builder::build;
 
         // then
         assertThatNoException().isThrownBy(create);
+    }
+
+    @Test
+    void 유저가_확인되지_않으면_마실_생성을_실패한다() {
+        // given
+        MasilBuilder builder = Masil.builder()
+            .depth1(addressDepth1)
+            .depth2(addressDepth2)
+            .depth3(addressDepth3)
+            .path(path)
+            .title(title)
+            .distance((int) path.getLength())
+            .totalTime(totalTime)
+            .startedAt(OffsetDateTime.now());
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MasilErrorCode.NULL_USER.getMessage());
+    }
+
+    @Test
+    void 썸네일_Url이_1024자를_넘으면_마실_생성을_실패한다() {
+        // given
+        String thumbnailUrl = faker.lorem()
+            .sentence(1020) + faker.internet()
+            .domainName();
+        MasilBuilder builder = Masil.builder()
+            .user(user)
+            .depth1(addressDepth1)
+            .depth2(addressDepth2)
+            .depth3(addressDepth3)
+            .path(path)
+            .title(title)
+            .distance((int) path.getLength())
+            .totalTime(totalTime)
+            .thumbnailUrl(thumbnailUrl)
+            .startedAt(OffsetDateTime.now());
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MasilErrorCode.THUMBNAIL_URL_TOO_LONG.getMessage());
+    }
+
+    @Test
+    void 마실_거리가_입력되지_않으면_마실_생성을_실패한다() {
+        // given
+        MasilBuilder builder = Masil.builder()
+            .user(user)
+            .depth1(addressDepth1)
+            .depth2(addressDepth2)
+            .depth3(addressDepth3)
+            .path(path)
+            .title(title)
+            .totalTime(totalTime)
+            .startedAt(OffsetDateTime.now());
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MasilErrorCode.NULL_DISTANCE.getMessage());
+    }
+
+    @Test
+    void 마실_총_시간이_입력되지_않으면_마실_생성을_실패한다() {
+        // given
+        MasilBuilder builder = Masil.builder()
+            .user(user)
+            .depth1(addressDepth1)
+            .depth2(addressDepth2)
+            .depth3(addressDepth3)
+            .path(path)
+            .title(title)
+            .distance((int) path.getLength())
+            .startedAt(OffsetDateTime.now());
+
+        // when
+        ThrowingCallable create = builder::build;
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MasilErrorCode.NULL_TOTAL_TIME.getMessage());
+    }
+
+    User createUser() {
+        String nickname = faker.funnyName()
+            .name();
+        LocalDate birthDate = faker.date()
+            .birthdayLocalDate(20, 40);
+        int height = faker.number()
+            .numberBetween(170, 190);
+        int weight = faker.number()
+            .numberBetween(60, 90);
+        long socialId = faker.random()
+            .nextLong(Long.MAX_VALUE);
+
+        return User.builder()
+            .nickname(nickname)
+            .exerciseIntensity(ExerciseIntensity.MIDDLE)
+            .sex(Sex.MALE)
+            .birthDate(Date.valueOf(birthDate))
+            .height(height)
+            .weight(weight)
+            .provider(Provider.KAKAO)
+            .socialId(String.valueOf(socialId))
+            .build();
+    }
+
+    LineString createLineString(int size) {
+        List<KakaoPoint> path = new ArrayList<>();
+        double dongAnLat = 37.4004;
+        double dongAnLng = 126.9555;
+        double appender = 0.002;
+
+        for (int i = 0; i < size; i++) {
+            dongAnLat += appender * i;
+            dongAnLng += appender * i;
+
+            KakaoPoint point = new KakaoPoint(dongAnLat, dongAnLng);
+
+            path.add(point);
+        }
+
+        return KakaoPointMapper.mapToLineString(path);
     }
 
 }

--- a/src/test/java/team/silvertown/masil/masil/domain/MasilTitleTest.java
+++ b/src/test/java/team/silvertown/masil/masil/domain/MasilTitleTest.java
@@ -1,0 +1,71 @@
+package team.silvertown.masil.masil.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Locale;
+import net.datafaker.Faker;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.masil.exception.MasilErrorCode;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MasilTitleTest {
+
+    static final Faker faker = new Faker(Locale.KOREA);
+
+    @Test
+    void 마실_제목_생성을_성공한다() {
+        // given
+        String title = faker.book()
+            .title();
+
+        // when
+        ThrowingCallable create = () -> new MasilTitle(title);
+
+        // then
+        assertThatNoException().isThrownBy(create);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 마실_제목이_비었으면_오늘_날짜를_붙여_제목을_생성한다(String title) {
+        // given
+        LocalDate today = OffsetDateTime.now()
+            .toLocalDate();
+        String expected = today + " 산책 기록";
+
+        // when
+        MasilTitle masilTitle = new MasilTitle(title);
+
+        // then
+        String actual = masilTitle.getTitle();
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void 마실_제목이_30자를_넘으면_제목_생성을_실패한다() {
+        // given
+        String title = faker.lorem()
+            .sentence(35);
+
+        // when
+        ThrowingCallable create = () -> new MasilTitle(title);
+
+        // then
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+            .withMessage(MasilErrorCode.TITLE_TOO_LONG.getMessage());
+    }
+
+}


### PR DESCRIPTION
* Resolves #21 

## 반영 사항
* 마실 및 관련 도메인 검증 추가
  * `Masil`
  * `MasilPin`
  * `Address`
* 카카오 포인트 -> Geometry (Point, LineString) 매퍼 구현
* 에러 코드 정의
  * `MasilErrorCode`
  * `MapErrorCode`

* 생성 API로 바로 올리려다 너무 방대해서 나눠서 올립니다