### PR TITLE
🚀 마실 단일 조회 API 구현

### DIFF
--- a/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
+++ b/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
@@ -1,9 +1,15 @@
 package team.silvertown.masil.common.map;
 
+import org.locationtech.jts.geom.Point;
+
 public record KakaoPoint(double lat, double lng) {
 
     public String toRawString() {
         return this.lat + " " + this.lng;
+    }
+
+    public static KakaoPoint from(Point point) {
+        return new KakaoPoint(point.getX(), point.getY());
     }
 
 }

--- a/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
+++ b/src/main/java/team/silvertown/masil/common/map/KakaoPoint.java
@@ -1,6 +1,6 @@
 package team.silvertown.masil.common.map;
 
-import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
 
 public record KakaoPoint(double lat, double lng) {
 
@@ -8,8 +8,8 @@ public record KakaoPoint(double lat, double lng) {
         return this.lat + " " + this.lng;
     }
 
-    public static KakaoPoint from(Point point) {
-        return new KakaoPoint(point.getX(), point.getY());
+    public static KakaoPoint from(Coordinate coordinate) {
+        return new KakaoPoint(coordinate.getX(), coordinate.getY());
     }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
+++ b/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
@@ -3,11 +3,14 @@ package team.silvertown.masil.masil.controller;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import team.silvertown.masil.masil.dto.CreateRequest;
 import team.silvertown.masil.masil.dto.CreateResponse;
+import team.silvertown.masil.masil.dto.MasilResponse;
 import team.silvertown.masil.masil.service.MasilService;
 
 @RestController
@@ -27,6 +30,16 @@ public class MasilController {
 
         return ResponseEntity.created(uri)
             .body(createResponse);
+    }
+
+    @GetMapping("/api/v1/masils/{id}")
+    public ResponseEntity<MasilResponse> getById(
+        @PathVariable
+        Long id
+    ) {
+        MasilResponse response = masilService.getById(1L, id);
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
+++ b/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
@@ -37,6 +37,7 @@ public class MasilController {
         @PathVariable
         Long id
     ) {
+        // TODO: Replace the temp user id to the one actual after login applied
         MasilResponse response = masilService.getById(1L, id);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -9,8 +9,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.AccessLevel;
@@ -69,6 +71,9 @@ public class Masil extends BaseEntity {
     @Column(name = "started_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
     @TimeZoneStorage(TimeZoneStorageType.NORMALIZE)
     private OffsetDateTime startedAt;
+
+    @OneToMany(mappedBy = "masil")
+    private List<MasilPin> masilPins = new ArrayList<>();
 
     @Builder
     private Masil(

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -11,6 +11,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,7 @@ import org.hibernate.annotations.TimeZoneStorageType;
 import org.locationtech.jts.geom.LineString;
 import team.silvertown.masil.common.BaseEntity;
 import team.silvertown.masil.common.map.Address;
+import team.silvertown.masil.common.map.KakaoPoint;
 import team.silvertown.masil.masil.exception.MasilErrorCode;
 import team.silvertown.masil.masil.validator.MasilValidator;
 import team.silvertown.masil.user.domain.User;
@@ -101,6 +104,28 @@ public class Masil extends BaseEntity {
 
     public String getTitle() {
         return this.title.getTitle();
+    }
+
+    public List<KakaoPoint> getKakaoPath() {
+        return Arrays.stream(this.path.getCoordinates())
+            .map(KakaoPoint::from)
+            .toList();
+    }
+
+    public String getDepth1() {
+        return this.address.getDepth1();
+    }
+
+    public String getDepth2() {
+        return this.address.getDepth2();
+    }
+
+    public String getDepth3() {
+        return this.address.getDepth3();
+    }
+
+    public String getDepth4() {
+        return this.address.getDepth4();
     }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -99,4 +99,8 @@ public class Masil extends BaseEntity {
         this.startedAt = startedAt;
     }
 
+    public String getTitle() {
+        return this.title.getTitle();
+    }
+
 }

--- a/src/main/java/team/silvertown/masil/masil/domain/Masil.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/Masil.java
@@ -45,6 +45,7 @@ public class Masil extends BaseEntity {
     private Long postId;
 
     @Embedded
+    @Getter(AccessLevel.NONE)
     private Address address;
 
     @Column(name = "path", nullable = false)

--- a/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
+++ b/src/main/java/team/silvertown/masil/masil/domain/MasilPin.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import team.silvertown.masil.common.BaseEntity;
+import team.silvertown.masil.common.map.KakaoPoint;
 import team.silvertown.masil.masil.exception.MasilErrorCode;
 import team.silvertown.masil.masil.validator.MasilValidator;
 
@@ -55,6 +56,10 @@ public class MasilPin extends BaseEntity {
         this.point = point;
         this.content = content;
         this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public KakaoPoint getSimplePoint() {
+        return KakaoPoint.from(this.point.getCoordinate());
     }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/dto/MasilResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/MasilResponse.java
@@ -1,27 +1,45 @@
 package team.silvertown.masil.masil.dto;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.Builder;
+import team.silvertown.masil.common.map.KakaoPoint;
 import team.silvertown.masil.masil.domain.Masil;
 
 @Builder
 public record MasilResponse(
     long id,
+    String depth1,
+    String depth2,
+    String depth3,
+    String depth4,
+    List<KakaoPoint> path,
     String title,
     String content,
     int distance,
     int totalTime,
-    List<PinResponse> pins
+    OffsetDateTime startedAt,
+    List<PinResponse> pins,
+    Long postId,
+    String thumbnailUrl
 ) {
 
     public static MasilResponse from(Masil masil, List<PinResponse> pins) {
         return MasilResponse.builder()
             .id(masil.getId())
+            .depth1(masil.getDepth1())
+            .depth2(masil.getDepth2())
+            .depth3(masil.getDepth3())
+            .depth4(masil.getDepth4())
+            .path(masil.getKakaoPath())
             .title(masil.getTitle())
             .content(masil.getContent())
             .distance(masil.getDistance())
             .totalTime(masil.getTotalTime())
+            .startedAt(masil.getStartedAt())
             .pins(pins)
+            .postId(masil.getPostId())
+            .thumbnailUrl(masil.getThumbnailUrl())
             .build();
     }
 

--- a/src/main/java/team/silvertown/masil/masil/dto/MasilResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/MasilResponse.java
@@ -1,0 +1,28 @@
+package team.silvertown.masil.masil.dto;
+
+import java.util.List;
+import lombok.Builder;
+import team.silvertown.masil.masil.domain.Masil;
+
+@Builder
+public record MasilResponse(
+    long id,
+    String title,
+    String content,
+    int distance,
+    int totalTime,
+    List<PinResponse> pins
+) {
+
+    public static MasilResponse from(Masil masil, List<PinResponse> pins) {
+        return MasilResponse.builder()
+            .id(masil.getId())
+            .title(masil.getTitle())
+            .content(masil.getContent())
+            .distance(masil.getDistance())
+            .totalTime(masil.getTotalTime())
+            .pins(pins)
+            .build();
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/dto/PinResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/PinResponse.java
@@ -13,11 +13,9 @@ public record PinResponse(
 ) {
 
     public static PinResponse from(MasilPin pin) {
-        KakaoPoint point = KakaoPoint.from(pin.getPoint());
-
         return PinResponse.builder()
             .id(pin.getId())
-            .point(point)
+            .point(pin.getSimplePoint())
             .content(pin.getContent())
             .thumbnailUrl(pin.getThumbnailUrl())
             .build();

--- a/src/main/java/team/silvertown/masil/masil/dto/PinResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/PinResponse.java
@@ -1,0 +1,26 @@
+package team.silvertown.masil.masil.dto;
+
+import lombok.Builder;
+import team.silvertown.masil.common.map.KakaoPoint;
+import team.silvertown.masil.masil.domain.MasilPin;
+
+@Builder
+public record PinResponse(
+    long id,
+    KakaoPoint point,
+    String content,
+    String thumbnailUrl
+) {
+
+    public static PinResponse from(MasilPin pin) {
+        KakaoPoint point = KakaoPoint.from(pin.getPoint());
+
+        return PinResponse.builder()
+            .id(pin.getId())
+            .point(point)
+            .content(pin.getContent())
+            .thumbnailUrl(pin.getThumbnailUrl())
+            .build();
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/dto/PinResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/PinResponse.java
@@ -1,7 +1,9 @@
 package team.silvertown.masil.masil.dto;
 
+import java.util.List;
 import lombok.Builder;
 import team.silvertown.masil.common.map.KakaoPoint;
+import team.silvertown.masil.masil.domain.Masil;
 import team.silvertown.masil.masil.domain.MasilPin;
 
 @Builder
@@ -19,6 +21,13 @@ public record PinResponse(
             .content(pin.getContent())
             .thumbnailUrl(pin.getThumbnailUrl())
             .build();
+    }
+
+    public static List<PinResponse> listFrom(Masil masil) {
+        return masil.getMasilPins()
+            .stream()
+            .map(PinResponse::from)
+            .toList();
     }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/exception/MasilErrorCode.java
+++ b/src/main/java/team/silvertown/masil/masil/exception/MasilErrorCode.java
@@ -10,8 +10,11 @@ public enum MasilErrorCode implements ErrorCode {
     INVALID_DISTANCE(20112000, "산책 거리는 양수여야 합니다"),
     INVALID_TOTAL_TIME(20112001, "산책 시간은 양수여야 합니다"),
 
+    USER_NOT_AUTHORIZED_FOR_MASIL(20120300, "해당 사용자는 해당 마실 조회 권한이 없습니다"),
+    MASIL_NOT_FOUND(201204000, "해당 아이디의 마실을 찾을 수 없습니다"),
+
     NULL_MASIL(20130000, "핀의 마실 기록을 확인할 수 없습니다"),
-    OWNER_NOT_MATCHING(20130001, "마실 기록의 사용자와 핀의 사용자가 다릅니다"),
+    PIN_OWNER_NOT_MATCHING(20130301, "마실 기록의 사용자와 핀의 사용자가 다릅니다"),
 
     NULL_USER(20190000, "마실 기록 사용자를 확인할 수 없습니다"),
     USER_NOT_FOUND(20190400, "마실 기록 사용자가 존재하지 않습니다");

--- a/src/main/java/team/silvertown/masil/masil/repository/MasilPinRepository.java
+++ b/src/main/java/team/silvertown/masil/masil/repository/MasilPinRepository.java
@@ -1,8 +1,12 @@
 package team.silvertown.masil.masil.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.silvertown.masil.masil.domain.Masil;
 import team.silvertown.masil.masil.domain.MasilPin;
 
 public interface MasilPinRepository extends JpaRepository<MasilPin, Long> {
+
+    List<MasilPin> findAllByMasil(Masil masil);
 
 }

--- a/src/main/java/team/silvertown/masil/masil/repository/MasilPinRepository.java
+++ b/src/main/java/team/silvertown/masil/masil/repository/MasilPinRepository.java
@@ -1,12 +1,8 @@
 package team.silvertown.masil.masil.repository;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import team.silvertown.masil.masil.domain.Masil;
 import team.silvertown.masil.masil.domain.MasilPin;
 
 public interface MasilPinRepository extends JpaRepository<MasilPin, Long> {
-
-    List<MasilPin> findAllByMasil(Masil masil);
 
 }

--- a/src/main/java/team/silvertown/masil/masil/service/MasilService.java
+++ b/src/main/java/team/silvertown/masil/masil/service/MasilService.java
@@ -52,10 +52,7 @@ public class MasilService {
 
         MasilValidator.validateMasilOwner(masil, user);
 
-        List<PinResponse> pins = masil.getMasilPins()
-            .stream()
-            .map(PinResponse::from)
-            .toList();
+        List<PinResponse> pins = PinResponse.listFrom(masil);
 
         return MasilResponse.from(masil, pins);
     }

--- a/src/main/java/team/silvertown/masil/masil/validator/MasilValidator.java
+++ b/src/main/java/team/silvertown/masil/masil/validator/MasilValidator.java
@@ -4,7 +4,7 @@ import io.micrometer.common.util.StringUtils;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.common.exception.ForbiddenException;
 import team.silvertown.masil.common.validator.Validator;
 import team.silvertown.masil.masil.domain.Masil;
 import team.silvertown.masil.masil.exception.MasilErrorCode;
@@ -28,11 +28,19 @@ public class MasilValidator extends Validator {
         }
     }
 
+    public static void validateMasilOwner(Masil masil, User user) {
+        User owner = masil.getUser();
+
+        notNull(owner, MasilErrorCode.NULL_USER);
+        throwIf(!Objects.equals(owner, user),
+            () -> new ForbiddenException(MasilErrorCode.USER_NOT_AUTHORIZED_FOR_MASIL));
+    }
+
     public static void validatePinOwner(Masil masil, Long userId) {
         User masilOwner = masil.getUser();
 
         throwIf(!Objects.equals(masilOwner.getId(), userId),
-            () -> new BadRequestException(MasilErrorCode.OWNER_NOT_MATCHING));
+            () -> new ForbiddenException(MasilErrorCode.PIN_OWNER_NOT_MATCHING));
     }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/validator/MasilValidator.java
+++ b/src/main/java/team/silvertown/masil/masil/validator/MasilValidator.java
@@ -32,7 +32,7 @@ public class MasilValidator extends Validator {
         User owner = masil.getUser();
 
         notNull(owner, MasilErrorCode.NULL_USER);
-        throwIf(!Objects.equals(owner, user),
+        throwIf(!owner.equals(user),
             () -> new ForbiddenException(MasilErrorCode.USER_NOT_AUTHORIZED_FOR_MASIL));
     }
 

--- a/src/test/java/team/silvertown/masil/masil/domain/MasilPinTest.java
+++ b/src/test/java/team/silvertown/masil/masil/domain/MasilPinTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.common.exception.ForbiddenException;
 import team.silvertown.masil.common.map.KakaoPoint;
 import team.silvertown.masil.common.map.KakaoPointMapper;
 import team.silvertown.masil.masil.domain.MasilPin.MasilPinBuilder;
@@ -108,7 +109,7 @@ class MasilPinTest {
         ThrowingCallable create = builder::build;
 
         // then
-        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+        assertThatExceptionOfType(ForbiddenException.class).isThrownBy(create)
             .withMessage(MasilErrorCode.PIN_OWNER_NOT_MATCHING.getMessage());
     }
 

--- a/src/test/java/team/silvertown/masil/masil/domain/MasilPinTest.java
+++ b/src/test/java/team/silvertown/masil/masil/domain/MasilPinTest.java
@@ -109,7 +109,7 @@ class MasilPinTest {
 
         // then
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
-            .withMessage(MasilErrorCode.OWNER_NOT_MATCHING.getMessage());
+            .withMessage(MasilErrorCode.PIN_OWNER_NOT_MATCHING.getMessage());
     }
 
     Masil createMasil() {

--- a/src/test/java/team/silvertown/masil/masil/service/MasilServiceTest.java
+++ b/src/test/java/team/silvertown/masil/masil/service/MasilServiceTest.java
@@ -3,14 +3,9 @@ package team.silvertown.masil.masil.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.sql.Date;
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import net.datafaker.Faker;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -18,6 +13,7 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.locationtech.jts.geom.Coordinate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,9 +29,9 @@ import team.silvertown.masil.masil.dto.MasilResponse;
 import team.silvertown.masil.masil.exception.MasilErrorCode;
 import team.silvertown.masil.masil.repository.MasilPinRepository;
 import team.silvertown.masil.masil.repository.MasilRepository;
-import team.silvertown.masil.user.domain.ExerciseIntensity;
-import team.silvertown.masil.user.domain.Provider;
-import team.silvertown.masil.user.domain.Sex;
+import team.silvertown.masil.texture.MapTexture;
+import team.silvertown.masil.texture.MasilTexture;
+import team.silvertown.masil.texture.UserTexture;
 import team.silvertown.masil.user.domain.User;
 import team.silvertown.masil.user.repository.UserRepository;
 
@@ -43,12 +39,6 @@ import team.silvertown.masil.user.repository.UserRepository;
 @Transactional
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class MasilServiceTest {
-
-    static final Faker faker = new Faker(Locale.KOREA);
-
-    static double dongAnLat = 37.4004;
-    static double dongAnLng = 126.9555;
-    static double appender = 0.002;
 
     @Autowired
     MasilService masilService;
@@ -73,20 +63,14 @@ class MasilServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = userRepository.save(createUser());
-        addressDepth1 = faker.address()
-            .state();
-        addressDepth2 = faker.address()
-            .city();
-        addressDepth3 = faker.address()
-            .streetName();
-        path = createPath(10000);
-        title = faker.lorem()
-            .maxLengthSentence(29);
-        distance = faker.number()
-            .numberBetween(1000, 1500);
-        totalTime = faker.number()
-            .numberBetween(10, 70);
+        user = userRepository.save(UserTexture.createValidUser());
+        addressDepth1 = MasilTexture.createAddressDepth1();
+        addressDepth2 = MasilTexture.createAddressDepth2();
+        addressDepth3 = MasilTexture.createAddressDepth3();
+        path = MapTexture.createPath(10000);
+        title = MasilTexture.getRandomFixedSentence(29);
+        distance = MasilTexture.getRandomPositive();
+        totalTime = MasilTexture.getRandomPositive();
     }
 
     @ParameterizedTest
@@ -114,8 +98,7 @@ class MasilServiceTest {
     @Test
     void 사용자가_존재하지_않으면_마실_생성을_실패한다() {
         // given
-        long invalidId = faker.random()
-            .nextLong(Long.MAX_VALUE);
+        long invalidId = MasilTexture.getRandomId();
         CreateRequest request = new CreateRequest(addressDepth1, addressDepth2, addressDepth3,
             "", path, title, null, distance, totalTime, OffsetDateTime.now(), null, null, null);
 
@@ -148,8 +131,7 @@ class MasilServiceTest {
     @Test
     void 사용자가_존재하지_않으면_마실_단일_조회를_실패한다() {
         // given
-        long invalidId = faker.random()
-            .nextLong(Long.MAX_VALUE);
+        long invalidId = MasilTexture.getRandomId();
 
         // when
         ThrowingCallable getById = () -> masilService.getById(invalidId, invalidId);
@@ -162,8 +144,7 @@ class MasilServiceTest {
     @Test
     void 마실이_존재하지_않으면_마실_단일_조회를_실패한다() {
         // given
-        long invalidId = faker.random()
-            .nextLong(Long.MAX_VALUE);
+        long invalidId = MasilTexture.getRandomId();
 
         // when
         ThrowingCallable getById = () -> masilService.getById(user.getId(), invalidId);
@@ -176,7 +157,7 @@ class MasilServiceTest {
     @Test
     void 로그인한_사용자와_마실_소유자가_다르면_마실_단일_조회를_실패한다() {
         // given
-        User differntUser = userRepository.save(createUser());
+        User differntUser = userRepository.save(UserTexture.createValidUser());
         List<CreatePinRequest> pinRequests = createPinRequests(10, 10000);
         CreateRequest request = new CreateRequest(addressDepth1, addressDepth2, addressDepth3,
             "", path, title, null, distance, totalTime,
@@ -191,61 +172,19 @@ class MasilServiceTest {
             .withMessage(MasilErrorCode.USER_NOT_AUTHORIZED_FOR_MASIL.getMessage());
     }
 
-    User createUser() {
-        String nickname = faker.funnyName()
-            .name();
-        LocalDate birthDate = faker.date()
-            .birthdayLocalDate(20, 40);
-        int height = faker.number()
-            .numberBetween(170, 190);
-        int weight = faker.number()
-            .numberBetween(60, 90);
-        long socialId = faker.random()
-            .nextLong(Long.MAX_VALUE);
-
-        return User.builder()
-            .nickname(nickname)
-            .exerciseIntensity(ExerciseIntensity.MIDDLE)
-            .sex(Sex.MALE)
-            .birthDate(Date.valueOf(birthDate))
-            .height(height)
-            .weight(weight)
-            .provider(Provider.KAKAO)
-            .socialId(String.valueOf(socialId))
-            .build();
-    }
-
     List<CreatePinRequest> createPinRequests(int size, int maxPathPoints) {
         List<CreatePinRequest> pinRequests = new ArrayList<>();
-        double maxAppender = appender * maxPathPoints;
-        double lat = faker.random()
-            .nextDouble(dongAnLat, dongAnLat * maxAppender);
-        double lng = faker.random()
-            .nextDouble(dongAnLng, dongAnLng * maxAppender);
 
         for (int i = 0; i < size; i++) {
-            KakaoPoint point = new KakaoPoint(lat, lng);
+            Coordinate coordinate = MapTexture.createPoint()
+                .getCoordinate();
+            KakaoPoint point = KakaoPoint.from(coordinate);
             CreatePinRequest createPinRequest = new CreatePinRequest(point, null, null);
 
             pinRequests.add(createPinRequest);
         }
 
         return pinRequests;
-    }
-
-    List<KakaoPoint> createPath(int size) {
-        List<KakaoPoint> path = new ArrayList<>();
-
-        for (int i = 0; i < size; i++) {
-            double lat = dongAnLat + appender * i;
-            double lng = dongAnLng + appender * i;
-
-            KakaoPoint point = new KakaoPoint(lat, lng);
-
-            path.add(point);
-        }
-
-        return path;
     }
 
 }

--- a/src/test/java/team/silvertown/masil/texture/BaseDomainTexture.java
+++ b/src/test/java/team/silvertown/masil/texture/BaseDomainTexture.java
@@ -21,7 +21,7 @@ public class BaseDomainTexture {
 
     public static String getRandomFixedSentence(int length) {
         return faker.lorem()
-            .sentence(length);
+            .characters(length);
     }
 
     public static int getRandomInt(int min, int max) {

--- a/src/test/java/team/silvertown/masil/texture/MasilTexture.java
+++ b/src/test/java/team/silvertown/masil/texture/MasilTexture.java
@@ -1,10 +1,14 @@
 package team.silvertown.masil.texture;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
 import team.silvertown.masil.masil.domain.Masil;
+import team.silvertown.masil.masil.domain.MasilPin;
 import team.silvertown.masil.user.domain.User;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -36,10 +40,23 @@ public final class MasilTexture extends BaseDomainTexture {
             .quote();
         String thumbnailUrl = createUrl();
 
-        return createMasil(postId, content, thumbnailUrl);
+        return createMasilWithOptional(postId, content, thumbnailUrl);
     }
 
-    public static Masil createMasil(Long postId, String content, String thumbnailUrl) {
+    public static Masil createDependentMasil(User user, int pathSize) {
+        String addressDepth1 = createAddressDepth1();
+        String addressDepth2 = createAddressDepth2();
+        String addressDepth3 = createAddressDepth3();
+        LineString path = MapTexture.createLineString(pathSize);
+        String title = getRandomSentenceWithMax(29);
+        int totalTime = getRandomInt(600, 4200);
+
+        return createMasil(user, null, addressDepth1, addressDepth2, addressDepth3, "", path,
+            title,
+            null, null, (int) path.getLength(), totalTime, OffsetDateTime.now());
+    }
+
+    public static Masil createMasilWithOptional(Long postId, String content, String thumbnailUrl) {
         User user = UserTexture.createValidUser();
         String addressDepth1 = createAddressDepth1();
         String addressDepth2 = createAddressDepth2();
@@ -82,6 +99,40 @@ public final class MasilTexture extends BaseDomainTexture {
             .totalTime(totalTime)
             .startedAt(startedAt)
             .build();
+    }
+
+    public static MasilPin createMasilPin(Masil masil, Long userId) {
+        Point point = MapTexture.createPoint();
+
+        return createMasilPin(masil, point, null, null, userId);
+    }
+
+    public static MasilPin createMasilPin(
+        Masil masil,
+        Point point,
+        String content,
+        String thumbnailUrl,
+        Long userId
+    ) {
+        return MasilPin.builder()
+            .userId(userId)
+            .point(point)
+            .content(content)
+            .thumbnailUrl(thumbnailUrl)
+            .masil(masil)
+            .build();
+    }
+
+    public static List<MasilPin> createDependentMasilPins(Masil masil, Long userId, int size) {
+        List<MasilPin> masilPins = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            MasilPin masilPin = createMasilPin(masil, userId);
+
+            masilPins.add(masilPin);
+        }
+
+        return masilPins;
     }
 
 }


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #31 

## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 마실 단일 조회 구현
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
* 로그인 구현 시 유저 연동 예정~
* **마실과 마실 핀 조회 방식**
  * 마실 조회 + 마실 핀 조회 => 쿼리 두 번
  * 한 번으로 줄일까 고민 -> QueryDSL 도입 고민
  * 개별 조회로 결정! 이유는 구현할 필요가 없이 간단하고 빠르게 할 수 있어서!!