### PR TITLE
🚀 최근 마실 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,9 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
+# Query DSL
+src/main/generated
+
 # Eclipse Gradle plugin generated files
 # Eclipse Core
 .project

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,6 @@ jacocoTestCoverageVerification {
 }
 
 clean {
-    delete file('src/main/generated')
+    delete file(querydslSrcDir)
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,18 @@ dependencies {
 
     // faker
     implementation 'net.datafaker:datafaker:2.1.0'
+
+    // query dsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+def querydslSrcDir = 'src/main/generated'
+
+compileJava {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }
 
 test {
@@ -108,8 +120,17 @@ jacocoTestCoverageVerification {
                     '*.domain.*',
                     '*.service.*'
             ]
+
+            excludes = [
+                    "*.Q*"
+            ]
         }
     }
 
     dependsOn jacocoTestReport
 }
+
+clean {
+    delete file('src/main/generated')
+}
+

--- a/src/main/java/team/silvertown/masil/common/response/SliceResponse.java
+++ b/src/main/java/team/silvertown/masil/common/response/SliceResponse.java
@@ -1,0 +1,15 @@
+package team.silvertown.masil.common.response;
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(
+    boolean hasNext,
+    List<T> contents
+) {
+
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<T>(slice.hasNext(), slice.getContent());
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
+++ b/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
@@ -58,6 +58,14 @@ public class MasilController {
     }
 
     @GetMapping("/api/v1/masils/recent")
+    @Operation(summary = "최근 마실 조회")
+    @ApiResponse(
+        responseCode = "200",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = RecentMasilResponse.class)
+        )
+    )
     public ResponseEntity<RecentMasilResponse> getRecent(
         @AuthenticationPrincipal
         Long userId,

--- a/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
+++ b/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
@@ -3,6 +3,7 @@ package team.silvertown.masil.masil.controller;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import team.silvertown.masil.masil.dto.CreateRequest;
 import team.silvertown.masil.masil.dto.CreateResponse;
 import team.silvertown.masil.masil.dto.MasilResponse;
+import team.silvertown.masil.masil.dto.RecentMasilResponse;
 import team.silvertown.masil.masil.service.MasilService;
 
 @RestController
@@ -25,11 +27,22 @@ public class MasilController {
         CreateRequest request
     ) {
         // TODO: Replace the temp user id to the one actual after login applied
-        CreateResponse createResponse = masilService.create(1L, request);
+        CreateResponse createResponse = masilService.create(2L, request);
         URI uri = URI.create("/api/v1/masils/" + createResponse.id());
 
         return ResponseEntity.created(uri)
             .body(createResponse);
+    }
+
+    @GetMapping("/api/v1/masils/recent")
+    public ResponseEntity<RecentMasilResponse> getRecent(
+        @AuthenticationPrincipal
+        Long userId,
+        Integer size
+    ) {
+        RecentMasilResponse response = masilService.getRecent(userId, size);
+
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/api/v1/masils/{id}")
@@ -38,7 +51,7 @@ public class MasilController {
         Long id
     ) {
         // TODO: Replace the temp user id to the one actual after login applied
-        MasilResponse response = masilService.getById(1L, id);
+        MasilResponse response = masilService.getById(2L, id);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
+++ b/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
@@ -23,11 +23,12 @@ public class MasilController {
 
     @PostMapping("/api/v1/masils")
     public ResponseEntity<CreateResponse> create(
+        @AuthenticationPrincipal
+        Long userId,
         @RequestBody
         CreateRequest request
     ) {
-        // TODO: Replace the temp user id to the one actual after login applied
-        CreateResponse createResponse = masilService.create(2L, request);
+        CreateResponse createResponse = masilService.create(userId, request);
         URI uri = URI.create("/api/v1/masils/" + createResponse.id());
 
         return ResponseEntity.created(uri)
@@ -47,11 +48,12 @@ public class MasilController {
 
     @GetMapping("/api/v1/masils/{id}")
     public ResponseEntity<MasilResponse> getById(
+        @AuthenticationPrincipal
+        Long userId,
         @PathVariable
         Long id
     ) {
-        // TODO: Replace the temp user id to the one actual after login applied
-        MasilResponse response = masilService.getById(2L, id);
+        MasilResponse response = masilService.getById(userId, id);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/team/silvertown/masil/masil/dto/RecentMasilResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/RecentMasilResponse.java
@@ -1,0 +1,7 @@
+package team.silvertown.masil.masil.dto;
+
+import java.util.List;
+
+public record RecentMasilResponse(List<SimpleMasilResponse> masils, boolean isEmpty) {
+
+}

--- a/src/main/java/team/silvertown/masil/masil/dto/SimpleMasilResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/SimpleMasilResponse.java
@@ -1,0 +1,22 @@
+package team.silvertown.masil.masil.dto;
+
+import java.time.OffsetDateTime;
+import lombok.Builder;
+import team.silvertown.masil.masil.domain.Masil;
+
+@Builder
+public record SimpleMasilResponse(
+    long id,
+    String thumbnailUrl,
+    OffsetDateTime startedAt
+) {
+
+    public static SimpleMasilResponse from(Masil masil) {
+        return SimpleMasilResponse.builder()
+            .id(masil.getId())
+            .startedAt(masil.getStartedAt())
+            .thumbnailUrl(masil.getThumbnailUrl())
+            .build();
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/repository/MasilQueryRepository.java
+++ b/src/main/java/team/silvertown/masil/masil/repository/MasilQueryRepository.java
@@ -1,0 +1,11 @@
+package team.silvertown.masil.masil.repository;
+
+import java.util.List;
+import team.silvertown.masil.masil.domain.Masil;
+import team.silvertown.masil.user.domain.User;
+
+public interface MasilQueryRepository {
+
+    List<Masil> findRecent(User user, Integer size);
+
+}

--- a/src/main/java/team/silvertown/masil/masil/repository/MasilQueryRepositoryImpl.java
+++ b/src/main/java/team/silvertown/masil/masil/repository/MasilQueryRepositoryImpl.java
@@ -1,0 +1,39 @@
+package team.silvertown.masil.masil.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Repository;
+import team.silvertown.masil.masil.domain.Masil;
+import team.silvertown.masil.masil.domain.QMasil;
+import team.silvertown.masil.user.domain.User;
+
+@Repository
+public class MasilQueryRepositoryImpl implements MasilQueryRepository {
+
+    private static final int DEFAULT_RECENT_SIZE = 10;
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public MasilQueryRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    public List<Masil> findRecent(User user, Integer size) {
+        QMasil masil = QMasil.masil;
+        int limit = DEFAULT_RECENT_SIZE;
+
+        if (Objects.nonNull(size) && size != 0) {
+            limit = size;
+        }
+
+        return jpaQueryFactory
+            .selectFrom(masil)
+            .where(masil.user.eq(user))
+            .limit(limit)
+            .orderBy(masil.id.desc())
+            .fetch();
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/repository/MasilRepository.java
+++ b/src/main/java/team/silvertown/masil/masil/repository/MasilRepository.java
@@ -3,6 +3,6 @@ package team.silvertown.masil.masil.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.silvertown.masil.masil.domain.Masil;
 
-public interface MasilRepository extends JpaRepository<Masil, Long> {
+public interface MasilRepository extends JpaRepository<Masil, Long>, MasilQueryRepository {
 
 }

--- a/src/main/java/team/silvertown/masil/masil/service/MasilService.java
+++ b/src/main/java/team/silvertown/masil/masil/service/MasilService.java
@@ -36,7 +36,7 @@ public class MasilService {
     @Transactional
     public CreateResponse create(Long userId, CreateRequest request) {
         User user = userRepository.findById(userId)
-            .orElseThrow(throwNotFound(MasilErrorCode.USER_NOT_FOUND));
+            .orElseThrow(getNotFoundException(MasilErrorCode.USER_NOT_FOUND));
         Masil masil = createMasil(request, user);
         Masil savedMasil = masilRepository.save(masil);
 
@@ -48,9 +48,9 @@ public class MasilService {
     @Transactional(readOnly = true)
     public MasilResponse getById(Long userId, Long id) {
         User user = userRepository.findById(userId)
-            .orElseThrow(throwNotFound(MasilErrorCode.USER_NOT_FOUND));
+            .orElseThrow(getNotFoundException(MasilErrorCode.USER_NOT_FOUND));
         Masil masil = masilRepository.findById(id)
-            .orElseThrow(throwNotFound(MasilErrorCode.MASIL_NOT_FOUND));
+            .orElseThrow(getNotFoundException(MasilErrorCode.MASIL_NOT_FOUND));
 
         MasilValidator.validateMasilOwner(masil, user);
 
@@ -62,7 +62,7 @@ public class MasilService {
     @Transactional(readOnly = true)
     public RecentMasilResponse getRecent(Long userId, Integer size) {
         User user = userRepository.findById(userId)
-            .orElseThrow(throwNotFound(MasilErrorCode.USER_NOT_FOUND));
+            .orElseThrow(getNotFoundException(MasilErrorCode.USER_NOT_FOUND));
         List<SimpleMasilResponse> masils = masilRepository.findRecent(user, size)
             .stream()
             .map(SimpleMasilResponse::from)
@@ -71,7 +71,7 @@ public class MasilService {
         return new RecentMasilResponse(masils, masils.isEmpty());
     }
 
-    private Supplier<DataNotFoundException> throwNotFound(ErrorCode errorCode) {
+    private Supplier<DataNotFoundException> getNotFoundException(ErrorCode errorCode) {
         return () -> new DataNotFoundException(errorCode);
     }
 

--- a/src/main/java/team/silvertown/masil/masil/service/MasilService.java
+++ b/src/main/java/team/silvertown/masil/masil/service/MasilService.java
@@ -59,6 +59,7 @@ public class MasilService {
         return MasilResponse.from(masil, pins);
     }
 
+    @Transactional(readOnly = true)
     public RecentMasilResponse getRecent(Long userId, Integer size) {
         User user = userRepository.findById(userId)
             .orElseThrow(throwNotFound(MasilErrorCode.USER_NOT_FOUND));

--- a/src/main/java/team/silvertown/masil/masil/service/MasilService.java
+++ b/src/main/java/team/silvertown/masil/masil/service/MasilService.java
@@ -16,6 +16,8 @@ import team.silvertown.masil.masil.dto.CreateRequest;
 import team.silvertown.masil.masil.dto.CreateResponse;
 import team.silvertown.masil.masil.dto.MasilResponse;
 import team.silvertown.masil.masil.dto.PinResponse;
+import team.silvertown.masil.masil.dto.RecentMasilResponse;
+import team.silvertown.masil.masil.dto.SimpleMasilResponse;
 import team.silvertown.masil.masil.exception.MasilErrorCode;
 import team.silvertown.masil.masil.repository.MasilPinRepository;
 import team.silvertown.masil.masil.repository.MasilRepository;
@@ -55,6 +57,17 @@ public class MasilService {
         List<PinResponse> pins = PinResponse.listFrom(masil);
 
         return MasilResponse.from(masil, pins);
+    }
+
+    public RecentMasilResponse getRecent(Long userId, Integer size) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(throwNotFound(MasilErrorCode.USER_NOT_FOUND));
+        List<SimpleMasilResponse> masils = masilRepository.findRecent(user, size)
+            .stream()
+            .map(SimpleMasilResponse::from)
+            .toList();
+
+        return new RecentMasilResponse(masils, masils.isEmpty());
     }
 
     private Supplier<DataNotFoundException> throwNotFound(ErrorCode errorCode) {

--- a/src/main/java/team/silvertown/masil/user/controller/UserController.java
+++ b/src/main/java/team/silvertown/masil/user/controller/UserController.java
@@ -1,5 +1,9 @@
 package team.silvertown.masil.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,14 +13,26 @@ import team.silvertown.masil.user.service.UserService;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "회원 관련 API")
 public class UserController {
 
     private final UserService userService;
 
     @GetMapping("api/v1/users/check-nickname")
-    public ResponseEntity<Void> nicknameCheck(@RequestParam String nickname){
+    @Operation(summary = "닉네임 중복 검사")
+    @ApiResponse(
+        responseCode = "204",
+        description = "중복되는 닉네임 없음",
+        content = @Content(
+            mediaType = "application/json"
+        )
+    )
+    public ResponseEntity<Void> nicknameCheck(
+        @RequestParam
+        String nickname
+    ) {
         userService.checkNickname(nickname);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
 }


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #32 

## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 마실 다중 조회 => **최근 마실 조회**로 변경됐습니다!
* Query DSL 도입
* 로그인 사용자의 최근 마실 조회
* 기본 사이즈 - 10개
* 공통의 `SliceResponse`추가
* 마실 생성, 단일 조회에 로그인 유저 아이디 사용
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->