### PR TITLE
🚀 기간 별 마실 조회 API 구현

### DIFF
--- a/src/main/java/team/silvertown/masil/common/util/DateTimeConverter.java
+++ b/src/main/java/team/silvertown/masil/common/util/DateTimeConverter.java
@@ -11,14 +11,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DateTimeConverter {
 
-    private static final ZoneOffset KrOffset = ZoneOffset.of("+09:00");
+    private static final ZoneOffset KR_OFFSET = ZoneOffset.of("+09:00");
 
     public static OffsetDateTime toBeginningOfDay(LocalDate date) {
-        return date.atTime(OffsetTime.of(LocalTime.MIDNIGHT, KrOffset));
+        return date.atTime(OffsetTime.of(LocalTime.MIDNIGHT, KR_OFFSET));
     }
 
     public static OffsetDateTime toEndOfDay(LocalDate date) {
-        return date.atTime(OffsetTime.of(LocalTime.MAX, KrOffset));
+        return date.atTime(OffsetTime.of(LocalTime.MAX, KR_OFFSET));
     }
 
 }

--- a/src/main/java/team/silvertown/masil/common/util/DateTimeConverter.java
+++ b/src/main/java/team/silvertown/masil/common/util/DateTimeConverter.java
@@ -1,0 +1,24 @@
+package team.silvertown.masil.common.util;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DateTimeConverter {
+
+    private static final ZoneOffset KrOffset = ZoneOffset.of("+09:00");
+
+    public static OffsetDateTime toBeginningOfDay(LocalDate date) {
+        return date.atTime(OffsetTime.of(LocalTime.MIDNIGHT, KrOffset));
+    }
+
+    public static OffsetDateTime toEndOfDay(LocalDate date) {
+        return date.atTime(OffsetTime.of(LocalTime.MAX, KrOffset));
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/config/QueryDslConfig.java
+++ b/src/main/java/team/silvertown/masil/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package team.silvertown.masil.config;
+
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
+++ b/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
@@ -79,6 +79,14 @@ public class MasilController {
     }
 
     @GetMapping("/api/v1/masils/period")
+    @Operation(summary = "기간 별 마실 조회")
+    @ApiResponse(
+        responseCode = "200",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = PeriodResponse.class)
+        )
+    )
     public ResponseEntity<PeriodResponse> getInGivenPeriod(
         @AuthenticationPrincipal
         Long userId,

--- a/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
+++ b/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
@@ -9,10 +9,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import team.silvertown.masil.masil.dto.CreateRequest;
-import team.silvertown.masil.masil.dto.CreateResponse;
-import team.silvertown.masil.masil.dto.MasilResponse;
-import team.silvertown.masil.masil.dto.RecentMasilResponse;
+import team.silvertown.masil.masil.dto.request.CreateRequest;
+import team.silvertown.masil.masil.dto.request.PeriodRequest;
+import team.silvertown.masil.masil.dto.response.CreateResponse;
+import team.silvertown.masil.masil.dto.response.MasilResponse;
+import team.silvertown.masil.masil.dto.response.PeriodResponse;
+import team.silvertown.masil.masil.dto.response.RecentMasilResponse;
 import team.silvertown.masil.masil.service.MasilService;
 
 @RestController
@@ -42,6 +44,17 @@ public class MasilController {
         Integer size
     ) {
         RecentMasilResponse response = masilService.getRecent(userId, size);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/v1/masils/period")
+    public ResponseEntity<PeriodResponse> getInGivenPeriod(
+        @AuthenticationPrincipal
+        Long userId,
+        PeriodRequest request
+    ) {
+        PeriodResponse response = masilService.getInGivenPeriod(userId, request);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/team/silvertown/masil/masil/dto/CreateResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/CreateResponse.java
@@ -1,5 +1,0 @@
-package team.silvertown.masil.masil.dto;
-
-public record CreateResponse(Long id) {
-
-}

--- a/src/main/java/team/silvertown/masil/masil/dto/MasilDailyDetailDto.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/MasilDailyDetailDto.java
@@ -1,0 +1,32 @@
+package team.silvertown.masil.masil.dto;
+
+import lombok.Getter;
+import team.silvertown.masil.masil.domain.MasilTitle;
+
+@Getter
+public class MasilDailyDetailDto {
+
+    private final long id;
+    private final String title;
+    private final String content;
+    private final String thumbnailUrl;
+    private final int distance;
+    private final int totalTime;
+
+    public MasilDailyDetailDto(
+        Long id,
+        MasilTitle title,
+        String content,
+        String thumbnailUrl,
+        Integer distance,
+        Integer totalTime
+    ) {
+        this.id = id;
+        this.title = title.getTitle();
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.distance = distance;
+        this.totalTime = totalTime;
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/masil/dto/MasilDailyDto.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/MasilDailyDto.java
@@ -1,0 +1,10 @@
+package team.silvertown.masil.masil.dto;
+
+import java.util.List;
+
+public record MasilDailyDto(
+    String date,
+    List<MasilDailyDetailDto> masils
+) {
+
+}

--- a/src/main/java/team/silvertown/masil/masil/dto/request/CreatePinRequest.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/request/CreatePinRequest.java
@@ -1,4 +1,4 @@
-package team.silvertown.masil.masil.dto;
+package team.silvertown.masil.masil.dto.request;
 
 import team.silvertown.masil.common.map.KakaoPoint;
 import team.silvertown.masil.common.map.MapErrorCode;

--- a/src/main/java/team/silvertown/masil/masil/dto/request/CreateRequest.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/request/CreateRequest.java
@@ -1,4 +1,4 @@
-package team.silvertown.masil.masil.dto;
+package team.silvertown.masil.masil.dto.request;
 
 
 import java.time.OffsetDateTime;

--- a/src/main/java/team/silvertown/masil/masil/dto/request/PeriodRequest.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/request/PeriodRequest.java
@@ -3,6 +3,7 @@ package team.silvertown.masil.masil.dto.request;
 import java.time.LocalDate;
 
 public record PeriodRequest(
+    // TODO: apply date parser
     LocalDate startDate,
     LocalDate endDate
 ) {

--- a/src/main/java/team/silvertown/masil/masil/dto/request/PeriodRequest.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/request/PeriodRequest.java
@@ -1,0 +1,10 @@
+package team.silvertown.masil.masil.dto.request;
+
+import java.time.LocalDate;
+
+public record PeriodRequest(
+    LocalDate startDate,
+    LocalDate endDate
+) {
+
+}

--- a/src/main/java/team/silvertown/masil/masil/dto/response/CreateResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/response/CreateResponse.java
@@ -1,0 +1,5 @@
+package team.silvertown.masil.masil.dto.response;
+
+public record CreateResponse(Long id) {
+
+}

--- a/src/main/java/team/silvertown/masil/masil/dto/response/MasilResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/response/MasilResponse.java
@@ -1,4 +1,4 @@
-package team.silvertown.masil.masil.dto;
+package team.silvertown.masil.masil.dto.response;
 
 import java.time.OffsetDateTime;
 import java.util.List;

--- a/src/main/java/team/silvertown/masil/masil/dto/response/PeriodResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/response/PeriodResponse.java
@@ -1,0 +1,12 @@
+package team.silvertown.masil.masil.dto.response;
+
+import java.util.List;
+import team.silvertown.masil.masil.dto.MasilDailyDto;
+
+public record PeriodResponse(
+    int totalDistance,
+    int totalCounts,
+    List<MasilDailyDto> masils
+) {
+
+}

--- a/src/main/java/team/silvertown/masil/masil/dto/response/PinResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/response/PinResponse.java
@@ -1,4 +1,4 @@
-package team.silvertown.masil.masil.dto;
+package team.silvertown.masil.masil.dto.response;
 
 import java.util.List;
 import lombok.Builder;

--- a/src/main/java/team/silvertown/masil/masil/dto/response/RecentMasilResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/response/RecentMasilResponse.java
@@ -1,4 +1,4 @@
-package team.silvertown.masil.masil.dto;
+package team.silvertown.masil.masil.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/team/silvertown/masil/masil/dto/response/SimpleMasilResponse.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/response/SimpleMasilResponse.java
@@ -1,4 +1,4 @@
-package team.silvertown.masil.masil.dto;
+package team.silvertown.masil.masil.dto.response;
 
 import java.time.OffsetDateTime;
 import lombok.Builder;

--- a/src/main/java/team/silvertown/masil/masil/repository/MasilQueryRepository.java
+++ b/src/main/java/team/silvertown/masil/masil/repository/MasilQueryRepository.java
@@ -1,11 +1,19 @@
 package team.silvertown.masil.masil.repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import team.silvertown.masil.masil.domain.Masil;
+import team.silvertown.masil.masil.dto.MasilDailyDto;
 import team.silvertown.masil.user.domain.User;
 
 public interface MasilQueryRepository {
 
     List<Masil> findRecent(User user, Integer size);
+
+    List<MasilDailyDto> findInGivenPeriod(
+        User user,
+        OffsetDateTime startDateTime,
+        OffsetDateTime endDateTime
+    );
 
 }

--- a/src/main/java/team/silvertown/masil/masil/repository/MasilQueryRepositoryImpl.java
+++ b/src/main/java/team/silvertown/masil/masil/repository/MasilQueryRepositoryImpl.java
@@ -1,24 +1,31 @@
 package team.silvertown.masil.masil.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.group.GroupExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import team.silvertown.masil.masil.domain.Masil;
 import team.silvertown.masil.masil.domain.QMasil;
+import team.silvertown.masil.masil.dto.MasilDailyDetailDto;
+import team.silvertown.masil.masil.dto.MasilDailyDto;
 import team.silvertown.masil.user.domain.User;
 
 @Repository
+@RequiredArgsConstructor
 public class MasilQueryRepositoryImpl implements MasilQueryRepository {
 
     private static final int DEFAULT_RECENT_SIZE = 10;
 
     private final JPAQueryFactory jpaQueryFactory;
-
-    public MasilQueryRepositoryImpl(EntityManager entityManager) {
-        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
-    }
 
     public List<Masil> findRecent(User user, Integer size) {
         QMasil masil = QMasil.masil;
@@ -34,6 +41,56 @@ public class MasilQueryRepositoryImpl implements MasilQueryRepository {
             .limit(limit)
             .orderBy(masil.id.desc())
             .fetch();
+    }
+
+    @Override
+    public List<MasilDailyDto> findInGivenPeriod(
+        User user,
+        OffsetDateTime startDateTime,
+        OffsetDateTime endDateTime
+    ) {
+        QMasil masil = QMasil.masil;
+        BooleanBuilder condition = new BooleanBuilder();
+        StringTemplate startDate = convertToLocalDate(masil.startedAt);
+
+        condition.and(masil.user.eq(user))
+            .and(masil.startedAt.between(startDateTime, endDateTime));
+
+        return jpaQueryFactory
+            .selectFrom(masil)
+            .where(condition)
+            .orderBy(masil.startedAt.asc())
+            .transform(
+                GroupBy.groupBy(startDate)
+                    .as(projectDailyDetail(masil))
+            )
+            .entrySet()
+            .stream()
+            .map(entry -> new MasilDailyDto(entry.getKey(), entry.getValue()))
+            .toList();
+    }
+
+    private StringTemplate convertToLocalDate(DateTimePath<OffsetDateTime> dateTime) {
+        return Expressions.stringTemplate(
+            "DATE_FORMAT({0}, '%Y-%m-%d')",
+            dateTime
+        );
+    }
+
+    private GroupExpression<MasilDailyDetailDto, List<MasilDailyDetailDto>> projectDailyDetail(
+        QMasil masil
+    ) {
+        return GroupBy.list(
+            Projections.constructor(
+                MasilDailyDetailDto.class,
+                masil.id,
+                masil.title,
+                masil.content,
+                masil.thumbnailUrl,
+                masil.distance,
+                masil.totalTime
+            )
+        );
     }
 
 }

--- a/src/main/java/team/silvertown/masil/masil/service/MasilService.java
+++ b/src/main/java/team/silvertown/masil/masil/service/MasilService.java
@@ -1,7 +1,12 @@
 package team.silvertown.masil.masil.service;
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,15 +14,20 @@ import org.springframework.transaction.annotation.Transactional;
 import team.silvertown.masil.common.exception.DataNotFoundException;
 import team.silvertown.masil.common.exception.ErrorCode;
 import team.silvertown.masil.common.map.KakaoPointMapper;
+import team.silvertown.masil.common.util.DateTimeConverter;
 import team.silvertown.masil.masil.domain.Masil;
 import team.silvertown.masil.masil.domain.MasilPin;
-import team.silvertown.masil.masil.dto.CreatePinRequest;
-import team.silvertown.masil.masil.dto.CreateRequest;
-import team.silvertown.masil.masil.dto.CreateResponse;
-import team.silvertown.masil.masil.dto.MasilResponse;
-import team.silvertown.masil.masil.dto.PinResponse;
-import team.silvertown.masil.masil.dto.RecentMasilResponse;
-import team.silvertown.masil.masil.dto.SimpleMasilResponse;
+import team.silvertown.masil.masil.dto.MasilDailyDetailDto;
+import team.silvertown.masil.masil.dto.MasilDailyDto;
+import team.silvertown.masil.masil.dto.request.CreatePinRequest;
+import team.silvertown.masil.masil.dto.request.CreateRequest;
+import team.silvertown.masil.masil.dto.request.PeriodRequest;
+import team.silvertown.masil.masil.dto.response.CreateResponse;
+import team.silvertown.masil.masil.dto.response.MasilResponse;
+import team.silvertown.masil.masil.dto.response.PeriodResponse;
+import team.silvertown.masil.masil.dto.response.PinResponse;
+import team.silvertown.masil.masil.dto.response.RecentMasilResponse;
+import team.silvertown.masil.masil.dto.response.SimpleMasilResponse;
 import team.silvertown.masil.masil.exception.MasilErrorCode;
 import team.silvertown.masil.masil.repository.MasilPinRepository;
 import team.silvertown.masil.masil.repository.MasilRepository;
@@ -59,6 +69,7 @@ public class MasilService {
         return MasilResponse.from(masil, pins);
     }
 
+    @Transactional(readOnly = true)
     public RecentMasilResponse getRecent(Long userId, Integer size) {
         User user = userRepository.findById(userId)
             .orElseThrow(throwNotFound(MasilErrorCode.USER_NOT_FOUND));
@@ -68,6 +79,20 @@ public class MasilService {
             .toList();
 
         return new RecentMasilResponse(masils, masils.isEmpty());
+    }
+
+    @Transactional(readOnly = true)
+    public PeriodResponse getInGivenPeriod(Long userId, PeriodRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(throwNotFound(MasilErrorCode.USER_NOT_FOUND));
+        OffsetDateTime startDateTime = getStartDateTime(request.startDate());
+        OffsetDateTime endDateTime = getEndDateTime(request.endDate(), startDateTime);
+        List<MasilDailyDto> dailyMasils = masilRepository.findInGivenPeriod(user, startDateTime,
+            endDateTime);
+        int totalCount = getTotalCount(dailyMasils);
+        int totalDistance = getTotalDistance(dailyMasils);
+
+        return new PeriodResponse(totalDistance, totalCount, dailyMasils);
     }
 
     private Supplier<DataNotFoundException> throwNotFound(ErrorCode errorCode) {
@@ -115,5 +140,52 @@ public class MasilService {
             .masil(masil)
             .build();
     }
+
+    private OffsetDateTime getStartDateTime(LocalDate date) {
+        LocalDate startDate = date;
+
+        if (Objects.isNull(date)) {
+            startDate = OffsetDateTime.now(ZoneId.of("Asia/Seoul"))
+                .toLocalDate()
+                .withDayOfMonth(1);
+        }
+
+        return DateTimeConverter.toBeginningOfDay(startDate);
+    }
+
+    private OffsetDateTime getEndDateTime(LocalDate date, OffsetDateTime startDateTime) {
+        LocalDate endDate = date;
+
+        if (Objects.isNull(date)) {
+            YearMonth yearMonth = YearMonth.of(startDateTime.getYear(), startDateTime.getMonth());
+            endDate = yearMonth.atEndOfMonth();
+        }
+
+        return DateTimeConverter.toEndOfDay(endDate);
+    }
+
+    private int getTotalCount(List<MasilDailyDto> dailyMasils) {
+        return dailyMasils.stream()
+            .mapToInt(dailyMasil -> dailyMasil.masils()
+                .size())
+            .sum();
+    }
+
+    private int getTotalDistance(List<MasilDailyDto> dailyMasils) {
+        return dailyMasils.stream()
+            .map(this::getDailyDistance)
+            .reduce(Integer::sum)
+            .orElse(0);
+    }
+
+    private int getDailyDistance(MasilDailyDto dailyMasil) {
+        BiFunction<Integer, MasilDailyDetailDto, Integer> accumulator = (accumulated, nextMasil) ->
+            accumulated + nextMasil.getDistance();
+
+        return dailyMasil.masils()
+            .stream()
+            .reduce(0, accumulator, Integer::sum);
+    }
+
 
 }

--- a/src/test/java/team/silvertown/masil/alias/H2Alias.java
+++ b/src/test/java/team/silvertown/masil/alias/H2Alias.java
@@ -1,0 +1,24 @@
+package team.silvertown.masil.alias;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class H2Alias {
+
+    public static String formatDate(Date date, String mysqlFormatPattern) {
+        String dateFormatPattern = mysqlFormatPattern
+            .replace("%Y", "yyyy")
+            .replace("%m", "MM")
+            .replace("%d", "dd");
+
+        return date.toInstant()
+            .atOffset(ZoneOffset.of("+09:00"))
+            .toLocalDate()
+            .format(DateTimeFormatter.ofPattern(dateFormatPattern));
+    }
+
+}

--- a/src/test/java/team/silvertown/masil/texture/MasilTexture.java
+++ b/src/test/java/team/silvertown/masil/texture/MasilTexture.java
@@ -51,9 +51,21 @@ public final class MasilTexture extends BaseDomainTexture {
         String title = getRandomSentenceWithMax(29);
         int totalTime = getRandomInt(600, 4200);
 
-        return createMasil(user, null, addressDepth1, addressDepth2, addressDepth3, "", path,
-            title,
+        return createMasil(user, null, addressDepth1, addressDepth2, addressDepth3, "", path, title,
             null, null, (int) path.getLength(), totalTime, OffsetDateTime.now());
+    }
+
+    public static Masil createMasilWithStartedAt(User user, OffsetDateTime startedAt) {
+        String addressDepth1 = createAddressDepth1();
+        String addressDepth2 = createAddressDepth2();
+        String addressDepth3 = createAddressDepth3();
+        LineString path = MapTexture.createLineString(1000);
+        String title = getRandomSentenceWithMax(29);
+        int totalTime = getRandomInt(600, 4200);
+
+        return createMasil(user, null, addressDepth1, addressDepth2, addressDepth3, "", path, title,
+            null, null,
+            (int) path.getLength(), totalTime, startedAt);
     }
 
     public static Masil createMasilWithOptional(Long postId, String content, String thumbnailUrl) {


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #33 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 기간 별 마실 조회 구현
* 기본 기간
  * 오늘을 포함한 달
  * 시작 날짜만 주어졌을 경우 시작 날짜 ~ 해당 달 말일
* 응답 형식이 조금 까다로워서 남깁니다. [명세](https://www.notion.so/prgrms/ce5e904a4dfc43cb897b073ef29f418b)
```json
{
	"totalDistance": 104200,
	"totalCounts": 50,
	"contents": [
		{
			"date": "2024-02-07",
			"masils": [
				{
					"id": 1,
					"title": "2024-02-07 산책 기록",
					"content": "기록들 주루루룰루ㅜㄱ",
					"thumbnailUrl": "url",
					"distance": 1100,
					"totalTime": 300
				},
				{
					"id": 2,
					"title": "2024-02-07 산책 기록",
					"content": "기록",
					"thumbnailUrl": "url",
					"distance": 1540,
					"totalTime": 300
				}
			]
		},
		{
			"date": "2024-02-10",
			"masils": [
				{
					"id": 3,
					"title": "2024-02-10 산책 기록",
					"content": "기록들 주루루룰루ㅜㄱ",
					"thumbnailUrl": "url",
					"distance": 1100,
					"totalTime": 300
				},
				{
					"id": 4,
					"title": "2024-02-10 산책 기록",
					"content": "기록",
					"thumbnailUrl": "url",
					"distance": 1540,
					"totalTime": 450
				}
			]
		}
	]
}
```
* QueryDSL `transform()`을 사용하기 위한 `QueryDslConfig`추가
  * https://github.com/querydsl/querydsl/issues/3428#issue-1451944140
* 마실 DTO가 너무 많아져서 응답, 요청 패키지를 나눴습니다
* QueryDSL을 또 추가하기가 뭐해서 #40 를 베이스로 했습니다
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
* 이해를 도울 트러블 슈팅
  * [QueryDSL - Timestamp(DateTime)를 Date로](https://www.notion.so/prgrms/QueryDSL-Timestamp-DateTime-Date-39b9c8003db344fea914bcb1cca07be7)
  * [QueryDSL - transform](https://www.notion.so/prgrms/QueryDSL-transform-42cd63436a104b38b97734276ff0a8b3)
  * [DB 집계 함수? or 애플리케이션 로직?](https://www.notion.so/prgrms/DB-or-2e4ab713e3a1476581b64cb76f14063b)