### PR TITLE
🚀 스웨거 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 
     // faker
     implementation 'net.datafaker:datafaker:2.1.0'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 test {

--- a/src/main/java/team/silvertown/masil/config/SwaggerConfig.java
+++ b/src/main/java/team/silvertown/masil/config/SwaggerConfig.java
@@ -1,12 +1,8 @@
 package team.silvertown.masil.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.security.OAuthFlow;
-import io.swagger.v3.oas.annotations.security.OAuthFlows;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -15,16 +11,6 @@ import org.springframework.context.annotation.Configuration;
         title = "마실가실 API"
     ),
     security = @SecurityRequirement(name = "카카오 로그인")
-)
-@SecurityScheme(
-    name = "카카오 로그인",
-    type = SecuritySchemeType.OAUTH2,
-    flows = @OAuthFlows(
-        authorizationCode = @OAuthFlow(
-            authorizationUrl = "${spring.security.oauth2.client.provider.kakao.authorization-uri}",
-            tokenUrl = "${spring.security.oauth2.client.provider.kakao.token-uri}"
-        )
-    )
 )
 public class SwaggerConfig {
 

--- a/src/main/java/team/silvertown/masil/config/SwaggerConfig.java
+++ b/src/main/java/team/silvertown/masil/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package team.silvertown.masil.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.OAuthFlow;
+import io.swagger.v3.oas.annotations.security.OAuthFlows;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(
+        title = "마실가실 API"
+    ),
+    security = @SecurityRequirement(name = "카카오 로그인")
+)
+@SecurityScheme(
+    name = "카카오 로그인",
+    type = SecuritySchemeType.OAUTH2,
+    flows = @OAuthFlows(
+        authorizationCode = @OAuthFlow(
+            authorizationUrl = "${spring.security.oauth2.client.provider.kakao.authorization-uri}",
+            tokenUrl = "${spring.security.oauth2.client.provider.kakao.token-uri}"
+        )
+    )
+)
+public class SwaggerConfig {
+
+}

--- a/src/main/java/team/silvertown/masil/config/SwaggerConfig.java
+++ b/src/main/java/team/silvertown/masil/config/SwaggerConfig.java
@@ -2,15 +2,13 @@ package team.silvertown.masil.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @OpenAPIDefinition(
     info = @Info(
         title = "마실가실 API"
-    ),
-    security = @SecurityRequirement(name = "카카오 로그인")
+    )
 )
 public class SwaggerConfig {
 

--- a/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
+++ b/src/main/java/team/silvertown/masil/masil/controller/MasilController.java
@@ -1,5 +1,11 @@
 package team.silvertown.masil.masil.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,11 +21,27 @@ import team.silvertown.masil.masil.service.MasilService;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "마실 관련 API")
 public class MasilController {
 
     public final MasilService masilService;
 
+
     @PostMapping("/api/v1/masils")
+    @Operation(summary = "마실 생성")
+    @ApiResponse(
+        responseCode = "201",
+        headers = {
+            @Header(
+                name = "해당 마실 조회 API",
+                description = "/api/v1/masils/{id}"
+            )
+        },
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = CreateResponse.class)
+        )
+    )
     public ResponseEntity<CreateResponse> create(
         @RequestBody
         CreateRequest request
@@ -33,6 +55,14 @@ public class MasilController {
     }
 
     @GetMapping("/api/v1/masils/{id}")
+    @Operation(summary = "마실 단일 조회")
+    @ApiResponse(
+        responseCode = "200",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = MasilResponse.class)
+        )
+    )
     public ResponseEntity<MasilResponse> getById(
         @PathVariable
         Long id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,9 @@ jwt:
   token-validity-in-seconds: ${TOKEN_EXPIRATION}
 server:
   port: ${SERVER_PORT}
+springdoc:
+  swagger-ui:
+    path: /docs
+    filter: true
+  api-docs:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,5 +41,3 @@ springdoc:
   swagger-ui:
     path: /docs
     filter: true
-  api-docs:
-    enabled: false


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #43 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* Springdocs(OpenAPI docs, Swagger UI 라이브러리) 도입
* 요청, 성공 응답 문서화
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
* 모든 환경에 스웨거를 적용할 것인지?
* 실패 응답도 문서화를 할 것인지?!
* 권한이 필요한 API에 대한 접근 필터링을 하기 위해 Authorization을 추가 할 수 있는데, 로그인 컨트롤러가 필요할 것 같습니다. 간단하게 createAdmin api 같은 것도 있으면 개발 중에 편리는 할 것 같아요