### PR TITLE
🚀 산책로 포스트 생성 API 구현

### DIFF
--- a/src/main/java/team/silvertown/masil/masil/dto/request/CreateRequest.java
+++ b/src/main/java/team/silvertown/masil/masil/dto/request/CreateRequest.java
@@ -35,7 +35,7 @@ public record CreateRequest(
         MasilValidator.validateUrl(thumbnailUrl);
         MasilValidator.notNull(distance, MasilErrorCode.INVALID_DISTANCE);
         MasilValidator.notNull(totalTime, MasilErrorCode.INVALID_TOTAL_TIME);
-        MasilValidator.notNull(path, MapErrorCode.NULL_KAKAO_POINT);
+        MasilValidator.notNull(path, MapErrorCode.NULL_PATH);
         MasilValidator.notUnder(path.size(), MIN_POINT_NUM, MapErrorCode.INSUFFICIENT_PATH_POINTS);
     }
 

--- a/src/main/java/team/silvertown/masil/masil/service/MasilService.java
+++ b/src/main/java/team/silvertown/masil/masil/service/MasilService.java
@@ -48,11 +48,10 @@ public class MasilService {
         User user = userRepository.findById(userId)
             .orElseThrow(getNotFoundException(MasilErrorCode.USER_NOT_FOUND));
         Masil masil = createMasil(request, user);
-        Masil savedMasil = masilRepository.save(masil);
 
-        savePins(request.pins(), savedMasil);
+        savePins(request.pins(), masil);
 
-        return new CreateResponse(savedMasil.getId());
+        return new CreateResponse(masil.getId());
     }
 
     @Transactional(readOnly = true)
@@ -100,7 +99,7 @@ public class MasilService {
     }
 
     private Masil createMasil(CreateRequest request, User user) {
-        return Masil.builder()
+        Masil masil = Masil.builder()
             .depth1(request.depth1())
             .depth2(request.depth2())
             .depth3(request.depth3())
@@ -115,6 +114,8 @@ public class MasilService {
             .totalTime(request.totalTime())
             .user(user)
             .build();
+
+        return masilRepository.save(masil);
     }
 
     private void savePins(List<CreatePinRequest> pins, Masil masil) {

--- a/src/main/java/team/silvertown/masil/post/controller/PostController.java
+++ b/src/main/java/team/silvertown/masil/post/controller/PostController.java
@@ -1,0 +1,34 @@
+package team.silvertown.masil.post.controller;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import team.silvertown.masil.post.dto.request.CreateRequest;
+import team.silvertown.masil.post.dto.response.CreateResponse;
+import team.silvertown.masil.post.service.PostService;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping("/api/v1/posts")
+    public ResponseEntity<CreateResponse> create(
+        @AuthenticationPrincipal
+        Long userId,
+        @RequestBody
+        CreateRequest request
+    ) {
+        CreateResponse response = postService.create(userId, request);
+        URI uri = URI.create("/api/v1/posts/" + response.id());
+
+        return ResponseEntity.created(uri)
+            .body(response);
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/post/domain/Post.java
+++ b/src/main/java/team/silvertown/masil/post/domain/Post.java
@@ -84,8 +84,8 @@ public class Post extends BaseEntity {
         PostValidator.notNull(user, PostErrorCode.NULL_USER);
         PostValidator.validateUrl(thumbnailUrl);
         PostValidator.validateTitle(title);
-        PostValidator.notUnder(distance, 0, PostErrorCode.INVALID_DISTANCE);
-        PostValidator.notUnder(totalTime, 0, PostErrorCode.INVALID_TOTAL_TIME);
+        PostValidator.notUnder(distance, 0, PostErrorCode.NON_POSITIVE_DISTANCE);
+        PostValidator.notUnder(totalTime, 0, PostErrorCode.NON_POSITIVE_TOTAL_TIME);
 
         this.user = user;
         this.address = new Address(depth1, depth2, depth3, depth4);

--- a/src/main/java/team/silvertown/masil/post/dto/request/CreatePinRequest.java
+++ b/src/main/java/team/silvertown/masil/post/dto/request/CreatePinRequest.java
@@ -1,0 +1,18 @@
+package team.silvertown.masil.post.dto.request;
+
+import team.silvertown.masil.common.map.KakaoPoint;
+import team.silvertown.masil.common.map.MapErrorCode;
+import team.silvertown.masil.post.validator.PostValidator;
+
+public record CreatePinRequest(
+    KakaoPoint point,
+    String content,
+    String thumbnailUrl
+) {
+
+    public CreatePinRequest {
+        PostValidator.notNull(point, MapErrorCode.NULL_KAKAO_POINT);
+        PostValidator.validateUrl(thumbnailUrl);
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/post/dto/request/CreateRequest.java
+++ b/src/main/java/team/silvertown/masil/post/dto/request/CreateRequest.java
@@ -1,0 +1,40 @@
+package team.silvertown.masil.post.dto.request;
+
+import java.util.List;
+import team.silvertown.masil.common.map.KakaoPoint;
+import team.silvertown.masil.common.map.MapErrorCode;
+import team.silvertown.masil.post.exception.PostErrorCode;
+import team.silvertown.masil.post.validator.PostValidator;
+
+public record CreateRequest(
+    String depth1,
+    String depth2,
+    String depth3,
+    String depth4,
+    List<KakaoPoint> path,
+    String title,
+    String content,
+    Integer distance,
+    Integer totalTime,
+    Boolean isPublic,
+    List<CreatePinRequest> pins,
+    String thumbnailUrl
+) {
+
+    private static final int MIN_POINT_NUM = 3;
+
+    public CreateRequest {
+        PostValidator.notBlank(depth1, MapErrorCode.BLANK_DEPTH1);
+        PostValidator.notNull(depth2, MapErrorCode.NULL_DEPTH2);
+        PostValidator.notBlank(depth3, MapErrorCode.BLANK_DEPTH3);
+        PostValidator.notNull(depth4, MapErrorCode.NULL_DEPTH4);
+        PostValidator.validateTitle(title);
+        PostValidator.validateUrl(thumbnailUrl);
+        PostValidator.notNull(distance, PostErrorCode.NON_POSITIVE_DISTANCE);
+        PostValidator.notNull(totalTime, PostErrorCode.NON_POSITIVE_TOTAL_TIME);
+        PostValidator.notNull(path, MapErrorCode.NULL_PATH);
+        PostValidator.notUnder(path.size(), MIN_POINT_NUM, MapErrorCode.INSUFFICIENT_PATH_POINTS);
+        PostValidator.notNull(isPublic, PostErrorCode.NULL_IS_PUBLIC);
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/post/dto/response/CreateResponse.java
+++ b/src/main/java/team/silvertown/masil/post/dto/response/CreateResponse.java
@@ -1,0 +1,5 @@
+package team.silvertown.masil.post.dto.response;
+
+public record CreateResponse(long id) {
+
+}

--- a/src/main/java/team/silvertown/masil/post/exception/PostErrorCode.java
+++ b/src/main/java/team/silvertown/masil/post/exception/PostErrorCode.java
@@ -5,17 +5,20 @@ import team.silvertown.masil.common.exception.ErrorCode;
 
 @Getter
 public enum PostErrorCode implements ErrorCode {
+    NULL_IS_PUBLIC(20210000, "산책로 포스트의 공개 여부를 확인할 수 없습니다"),
+
     THUMBNAIL_URL_TOO_LONG(20211000, "산책로 포스트썸네일 URL 주소 길이가 제한을 초과했습니다"),
     TITLE_TOO_LONG(20211001, "산책로 포스트 제목 길이가 제한을 초과했습니다"),
     BLANK_TITLE(20211002, "산책로 포스트 제목이 입력되지 않았습니다"),
 
-    INVALID_DISTANCE(20212000, "산책로 포스트의 산책 거리는 양수여야 합니다"),
-    INVALID_TOTAL_TIME(20212001, "산책로 포스트의 산책 시간은 양수여야 합니다"),
+    NON_POSITIVE_DISTANCE(20212000, "산책로 포스트의 산책 거리는 양수여야 합니다"),
+    NON_POSITIVE_TOTAL_TIME(20212001, "산책로 포스트의 산책 시간은 양수여야 합니다"),
 
     NULL_MASIL(20230000, "핀의 산책로 포스트를 확인할 수 없습니다"),
     PIN_OWNER_NOT_MATCHING(20230300, "산책로 포스트의 사용자와 핀의 사용자가 다릅니다"),
 
-    NULL_USER(20290000, "산책로 포스트 사용자를 확인할 수 없습니다");
+    NULL_USER(20290000, "산책로 포스트 사용자를 확인할 수 없습니다"),
+    USER_NOT_FOUND(20190400, "마실 기록 사용자가 존재하지 않습니다");
 
     private final int code;
     private final String message;

--- a/src/main/java/team/silvertown/masil/post/repository/PostPinRepository.java
+++ b/src/main/java/team/silvertown/masil/post/repository/PostPinRepository.java
@@ -1,0 +1,8 @@
+package team.silvertown.masil.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.silvertown.masil.post.domain.PostPin;
+
+public interface PostPinRepository extends JpaRepository<PostPin, Long> {
+
+}

--- a/src/main/java/team/silvertown/masil/post/repository/PostRepository.java
+++ b/src/main/java/team/silvertown/masil/post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package team.silvertown.masil.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.silvertown.masil.post.domain.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/team/silvertown/masil/post/service/PostService.java
+++ b/src/main/java/team/silvertown/masil/post/service/PostService.java
@@ -31,7 +31,7 @@ public class PostService {
     @Transactional
     public CreateResponse create(Long userId, CreateRequest request) {
         User user = userRepository.findById(userId)
-            .orElseThrow(throwNotFound(PostErrorCode.USER_NOT_FOUND));
+            .orElseThrow(getNotFoundException(PostErrorCode.USER_NOT_FOUND));
         Post post = createPost(request, user);
 
         savePins(request.pins(), post);
@@ -39,7 +39,7 @@ public class PostService {
         return new CreateResponse(post.getId());
     }
 
-    private Supplier<DataNotFoundException> throwNotFound(ErrorCode errorCode) {
+    private Supplier<DataNotFoundException> getNotFoundException(ErrorCode errorCode) {
         return () -> new DataNotFoundException(errorCode);
     }
 

--- a/src/main/java/team/silvertown/masil/post/service/PostService.java
+++ b/src/main/java/team/silvertown/masil/post/service/PostService.java
@@ -1,0 +1,89 @@
+package team.silvertown.masil.post.service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.silvertown.masil.common.exception.DataNotFoundException;
+import team.silvertown.masil.common.exception.ErrorCode;
+import team.silvertown.masil.common.map.KakaoPointMapper;
+import team.silvertown.masil.post.domain.Post;
+import team.silvertown.masil.post.domain.PostPin;
+import team.silvertown.masil.post.dto.request.CreatePinRequest;
+import team.silvertown.masil.post.dto.request.CreateRequest;
+import team.silvertown.masil.post.dto.response.CreateResponse;
+import team.silvertown.masil.post.exception.PostErrorCode;
+import team.silvertown.masil.post.repository.PostPinRepository;
+import team.silvertown.masil.post.repository.PostRepository;
+import team.silvertown.masil.user.domain.User;
+import team.silvertown.masil.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final PostPinRepository postPinRepository;
+
+    @Transactional
+    public CreateResponse create(Long userId, CreateRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(throwNotFound(PostErrorCode.USER_NOT_FOUND));
+        Post post = createPost(request, user);
+
+        savePins(request.pins(), post);
+
+        return new CreateResponse(post.getId());
+    }
+
+    private Supplier<DataNotFoundException> throwNotFound(ErrorCode errorCode) {
+        return () -> new DataNotFoundException(errorCode);
+    }
+
+    private Post createPost(CreateRequest request, User user) {
+        Post post = Post.builder()
+            .user(user)
+            .depth1(request.depth1())
+            .depth2(request.depth2())
+            .depth3(request.depth3())
+            .depth4(request.depth4())
+            .path(KakaoPointMapper.mapToLineString(request.path()))
+            .title(request.title())
+            .content(request.content())
+            .distance(request.distance())
+            .totalTime(request.totalTime())
+            .isPublic(request.isPublic())
+            .thumbnailUrl(request.thumbnailUrl())
+            .build();
+
+        return postRepository.save(post);
+    }
+
+    private void savePins(List<CreatePinRequest> pins, Post post) {
+        if (Objects.nonNull(pins)) {
+            pins.forEach(pin -> savePin(pin, post));
+        }
+    }
+
+    private void savePin(CreatePinRequest pin, Post post) {
+        PostPin postPin = createPin(pin, post);
+
+        postPinRepository.save(postPin);
+    }
+
+    private PostPin createPin(CreatePinRequest request, Post post) {
+        User owner = post.getUser();
+
+        return PostPin.builder()
+            .userId(owner.getId())
+            .point(KakaoPointMapper.mapToPoint(request.point()))
+            .content(request.content())
+            .thumbnailUrl(request.thumbnailUrl())
+            .post(post)
+            .build();
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/post/validator/PostValidator.java
+++ b/src/main/java/team/silvertown/masil/post/validator/PostValidator.java
@@ -18,7 +18,7 @@ public final class PostValidator extends Validator {
 
     public static void validateTitle(String title) {
         notBlank(title, PostErrorCode.BLANK_TITLE);
-        range(title.length(), 0, MAX_TITLE_LENGTH, PostErrorCode.TITLE_TOO_LONG);
+        notOver(title.length(), MAX_TITLE_LENGTH, PostErrorCode.TITLE_TOO_LONG);
     }
 
     public static void validateUrl(String url) {

--- a/src/test/java/team/silvertown/masil/post/domain/PostTest.java
+++ b/src/test/java/team/silvertown/masil/post/domain/PostTest.java
@@ -179,7 +179,7 @@ class PostTest {
 
         // then
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
-            .withMessage(PostErrorCode.INVALID_DISTANCE.getMessage());
+            .withMessage(PostErrorCode.NON_POSITIVE_DISTANCE.getMessage());
     }
 
     @ParameterizedTest
@@ -203,7 +203,7 @@ class PostTest {
 
         // then
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
-            .withMessage(PostErrorCode.INVALID_TOTAL_TIME.getMessage());
+            .withMessage(PostErrorCode.NON_POSITIVE_TOTAL_TIME.getMessage());
     }
 
 }

--- a/src/test/java/team/silvertown/masil/post/service/PostServiceTest.java
+++ b/src/test/java/team/silvertown/masil/post/service/PostServiceTest.java
@@ -1,0 +1,124 @@
+package team.silvertown.masil.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.locationtech.jts.geom.Coordinate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import team.silvertown.masil.common.exception.DataNotFoundException;
+import team.silvertown.masil.common.map.KakaoPoint;
+import team.silvertown.masil.post.domain.Post;
+import team.silvertown.masil.post.domain.PostPin;
+import team.silvertown.masil.post.dto.request.CreatePinRequest;
+import team.silvertown.masil.post.dto.request.CreateRequest;
+import team.silvertown.masil.post.dto.response.CreateResponse;
+import team.silvertown.masil.post.exception.PostErrorCode;
+import team.silvertown.masil.post.repository.PostPinRepository;
+import team.silvertown.masil.post.repository.PostRepository;
+import team.silvertown.masil.texture.MapTexture;
+import team.silvertown.masil.texture.MasilTexture;
+import team.silvertown.masil.texture.PostTexture;
+import team.silvertown.masil.texture.UserTexture;
+import team.silvertown.masil.user.domain.User;
+import team.silvertown.masil.user.repository.UserRepository;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PostServiceTest {
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    PostPinRepository postPinRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    User user;
+    String addressDepth1;
+    String addressDepth2;
+    String addressDepth3;
+    List<KakaoPoint> path;
+    String title;
+    int distance;
+    int totalTime;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(UserTexture.createValidUser());
+        addressDepth1 = MasilTexture.createAddressDepth1();
+        addressDepth2 = MasilTexture.createAddressDepth2();
+        addressDepth3 = MasilTexture.createAddressDepth3();
+        path = MapTexture.createPath(10000);
+        title = PostTexture.getRandomSentenceWithMax(29);
+        distance = PostTexture.getRandomPositive();
+        totalTime = PostTexture.getRandomPositive();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 0})
+    void 산책로_포스트_생성을_성공한다(int expectedPinCount) {
+        // given
+        List<CreatePinRequest> pinRequests = createPinRequests(expectedPinCount, 10000);
+        CreateRequest request = new CreateRequest(addressDepth1, addressDepth2, addressDepth3,
+            "", path, title, null, distance, totalTime, true, pinRequests, null);
+
+        // when
+        CreateResponse expected = postService.create(user.getId(), request);
+
+        // then
+        Post actual = postRepository.findById(expected.id())
+            .orElseThrow();
+        List<PostPin> actualPins = postPinRepository.findAll();
+
+        assertThat(actual.getId()).isEqualTo(expected.id());
+        assertThat(actualPins.size()).isEqualTo(expectedPinCount);
+    }
+
+    @Test
+    void 사용자가_존재하지_않으면_산책로_포스트_생성을_실패한다() {
+        // given
+        long invalidId = PostTexture.getRandomId();
+        CreateRequest request = new CreateRequest(addressDepth1, addressDepth2, addressDepth3,
+            "", path, title, null, distance, totalTime, true, null, null);
+
+        // when
+        ThrowingCallable create = () -> postService.create(invalidId, request);
+
+        // then
+        assertThatExceptionOfType(DataNotFoundException.class).isThrownBy(create)
+            .withMessage(PostErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    List<CreatePinRequest> createPinRequests(int size, int maxPathPoints) {
+        List<CreatePinRequest> pinRequests = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            Coordinate coordinate = MapTexture.createPoint()
+                .getCoordinate();
+            KakaoPoint point = KakaoPoint.from(coordinate);
+            CreatePinRequest createPinRequest = new CreatePinRequest(point, null, null);
+
+            pinRequests.add(createPinRequest);
+        }
+
+        return pinRequests;
+    }
+
+}


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #50 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 포스트/포스트핀 생성 로직
* 포스트 생성 API 엔드포인트
* 마실과 비슷하게 했습니다
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
