### PR TITLE
⚒️ user me api 요청 시 분기처리를 원할하게 처리

### DIFF
--- a/src/main/java/team/silvertown/masil/config/security/HttpRequestsConfigurer.java
+++ b/src/main/java/team/silvertown/masil/config/security/HttpRequestsConfigurer.java
@@ -10,8 +10,6 @@ public class HttpRequestsConfigurer
     implements
     Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> {
 
-    private static final String USER_INFO_REQUEST = "/api/v1/users/me";
-    private static final String NORMAL_USER_ROLE = "NORMAL";
     private static final String AUTH_RESOURCE = "/api/v1/users/login";
 
     @Override
@@ -21,8 +19,6 @@ public class HttpRequestsConfigurer
         authorizeRequests
             .requestMatchers(AUTH_RESOURCE)
             .permitAll()
-            .requestMatchers(USER_INFO_REQUEST)
-            .hasRole(NORMAL_USER_ROLE)
             .anyRequest()
             .authenticated();
     }

--- a/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
+++ b/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
@@ -20,11 +20,9 @@ public class UserValidator extends Validator {
     }
 
     public static void validateNickname(String nickname, UserErrorCode userErrorCode) {
-        if (nickname != null) {
-            notBlank(nickname, userErrorCode);
-            range(nickname.length(), 2, 12, userErrorCode);
-            notMatching(nickname, VALID_NICKNAME_PATTERN, userErrorCode);
-        }
+        notBlank(nickname, userErrorCode);
+        range(nickname.length(), 2, 12, userErrorCode);
+        notMatching(nickname, VALID_NICKNAME_PATTERN, userErrorCode);
     }
 
     public static void validateSex(String sex, UserErrorCode userErrorCode) {

--- a/src/test/java/team/silvertown/masil/user/dto/OnboardRequestTest.java
+++ b/src/test/java/team/silvertown/masil/user/dto/OnboardRequestTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -94,7 +95,7 @@ class OnboardRequestTest {
 
         @ParameterizedTest
         @Transactional
-        @EmptySource
+        @NullAndEmptySource
         @ValueSource(strings = {" ", "a", "_sjf!", "ssssssssssssssssss"})
         public void 유효하지_않은_닉네임이_들어올_시_예외를_발생시킨다(String invalidNickname) throws Exception {
             //given, when, then

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,14 +9,3 @@ spring:
     open-in-view: false
   flyway:
     enabled: false
-  cloud:
-    aws:
-      credentials:
-        accessKey: ${AWS_ACCESS_KEY_ID}
-        secretKey: ${AWS_SECRET_ACCESS_KEY}
-      region:
-        static: ap-northeast-2
-      s3:
-        bucket: ${AWS_S3_IMAGE_BUCKET}
-        endpoint: ${AWS_S3_IMAGE_ENDPOINT}
-        path-style-access-enabled: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,3 +9,14 @@ spring:
     open-in-view: false
   flyway:
     enabled: false
+  cloud:
+    aws:
+      credentials:
+        accessKey: ${AWS_ACCESS_KEY_ID}
+        secretKey: ${AWS_SECRET_ACCESS_KEY}
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: ${AWS_S3_IMAGE_BUCKET}
+        endpoint: ${AWS_S3_IMAGE_ENDPOINT}
+        path-style-access-enabled: true


### PR DESCRIPTION
## 🎫 관련 이슈

* Resolves #72 
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 주요 변경사항
- me api 에 있던 `hasRole()` 부분을 삭제
- 인증된 사용자에 대해서는 모두 요청을 할 수 있게 설정
- 프론트에서는 필수 정보인 `nickname` 값이 부재할 경우 추가 정보 페이지로 넘어가게 설정

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
