### PR TITLE
fix: 이미 존재하는 회원은 userId 가져온 후 토큰 생성하는 로직으로 변경

### DIFF
--- a/src/main/java/team/silvertown/masil/user/service/UserService.java
+++ b/src/main/java/team/silvertown/masil/user/service/UserService.java
@@ -2,6 +2,7 @@ package team.silvertown.masil.user.service;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -67,8 +68,10 @@ public class UserService {
     }
 
     private LoginResponse joinedUserResponse(Provider provider, OAuthResponse oAuthResponse) {
-        User alreadyJoinedUser = createAndSave(provider, oAuthResponse.providerId());
-        String token = tokenProvider.createToken(alreadyJoinedUser.getId());
+        User joinedUser = userRepository.findByProviderAndSocialId(provider,
+                oAuthResponse.providerId())
+            .orElseThrow(() -> new DataNotFoundException(UserErrorCode.USER_NOT_FOUND));
+        String token = tokenProvider.createToken(joinedUser.getId());
 
         return new LoginResponse(token);
     }

--- a/src/main/java/team/silvertown/masil/user/service/UserService.java
+++ b/src/main/java/team/silvertown/masil/user/service/UserService.java
@@ -54,10 +54,10 @@ public class UserService {
         }
 
         Provider provider = Provider.get(oAuthResponse.provider());
-        boolean isJoined = userRepository.existsByProviderAndSocialId(provider,
+        Optional<User> user = userRepository.findByProviderAndSocialId(provider,
             oAuthResponse.providerId());
-        if (isJoined) {
-            return joinedUserResponse(provider, oAuthResponse);
+        if (user.isPresent()) {
+            return joinedUserResponse(user.get());
         }
 
         User justSavedUser = createAndSave(provider, oAuthResponse.providerId());
@@ -67,10 +67,7 @@ public class UserService {
         return new LoginResponse(newUserToken);
     }
 
-    private LoginResponse joinedUserResponse(Provider provider, OAuthResponse oAuthResponse) {
-        User joinedUser = userRepository.findByProviderAndSocialId(provider,
-                oAuthResponse.providerId())
-            .orElseThrow(() -> new DataNotFoundException(UserErrorCode.USER_NOT_FOUND));
+    private LoginResponse joinedUserResponse(User joinedUser) {
         String token = tokenProvider.createToken(joinedUser.getId());
 
         return new LoginResponse(token);


### PR DESCRIPTION
기존에 join 한 유저더라도 다시 생성하는 문제 해결

## 🎫 관련 이슈

* Resolves #74 
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 주요 변경사항
- [x] createAndSave 로직에서 join 한 유저는 provider, socialId 기반으로 가져온 후 그 아이디를 토큰 claim에 넣어서 반환하는 로직으로 변경
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
