### PR TITLE
🔥 이미지 파일 확장자 누락 오류 수정

### DIFF
--- a/src/main/java/team/silvertown/masil/image/service/ImageService.java
+++ b/src/main/java/team/silvertown/masil/image/service/ImageService.java
@@ -10,6 +10,7 @@ import java.util.Base64.Encoder;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import team.silvertown.masil.image.config.S3Properties;
 
@@ -18,6 +19,8 @@ import team.silvertown.masil.image.config.S3Properties;
 public class ImageService {
 
     private static final Encoder encoder = Base64.getEncoder();
+    private static final String FILENAME_FORMAT = "{0}.{1}";
+    private static final String URI_FORMAT = "{0}/{1}/{2}";
 
     private final S3Properties s3Properties;
     private final S3Template s3Template;
@@ -35,15 +38,19 @@ public class ImageService {
     }
 
     private String generateKey(String filename) {
-        String uuid = UUID.randomUUID().toString();
-        byte[] key = (uuid + filename).getBytes();
+        String name = StringUtils.getFilename(filename);
+        String ext = StringUtils.getFilenameExtension(filename);
 
-        return encoder.encodeToString(key);
+        String uuid = UUID.randomUUID().toString();
+        String newName = uuid + name;
+        String encode = encoder.encodeToString(newName.getBytes());
+
+        return MessageFormat.format(FILENAME_FORMAT, encode, ext);
     }
 
     private URI createURI(String key) {
         String uri = MessageFormat.format(
-            "{0}/{1}/{2}",
+            URI_FORMAT,
             s3Properties.endpoint(),
             s3Properties.bucket(),
             key);


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- #45 

## 🚀 주요 변경사항

- 이미지 파일 업로드 시
- 리소스 링크에서 파일 확장자가 누락되는 오류 수정

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
