### PR TITLE
⚙️ 닉네임 중복체크 로직 및 response 변경

### DIFF
--- a/src/main/java/team/silvertown/masil/user/controller/UserController.java
+++ b/src/main/java/team/silvertown/masil/user/controller/UserController.java
@@ -51,7 +51,7 @@ public class UserController {
     @GetMapping("api/v1/users/check-nickname")
     @Operation(summary = "닉네임 중복 검사")
     @ApiResponse(
-        responseCode = "204",
+        responseCode = "200",
         description = "중복되는 닉네임 없음"
     )
     public ResponseEntity<NicknameCheckResponse> nicknameCheck(

--- a/src/main/java/team/silvertown/masil/user/controller/UserController.java
+++ b/src/main/java/team/silvertown/masil/user/controller/UserController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.silvertown.masil.user.dto.LoginResponse;
 import team.silvertown.masil.user.dto.MeInfoResponse;
+import team.silvertown.masil.user.dto.NicknameCheckResponse;
 import team.silvertown.masil.user.dto.OnboardRequest;
 import team.silvertown.masil.user.service.UserService;
 
@@ -53,13 +54,11 @@ public class UserController {
         responseCode = "204",
         description = "중복되는 닉네임 없음"
     )
-    public ResponseEntity<Void> nicknameCheck(
+    public ResponseEntity<NicknameCheckResponse> nicknameCheck(
         @RequestParam
         String nickname
     ) {
-        userService.checkNickname(nickname);
-        return ResponseEntity.noContent()
-            .build();
+        return ResponseEntity.ok(userService.checkNickname(nickname));
     }
 
     @GetMapping("/api/v1/users/me")

--- a/src/main/java/team/silvertown/masil/user/dto/NicknameCheckResponse.java
+++ b/src/main/java/team/silvertown/masil/user/dto/NicknameCheckResponse.java
@@ -1,0 +1,11 @@
+package team.silvertown.masil.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record NicknameCheckResponse (
+    Boolean isDuplicated,
+    String nickname
+){
+
+}

--- a/src/main/java/team/silvertown/masil/user/service/UserService.java
+++ b/src/main/java/team/silvertown/masil/user/service/UserService.java
@@ -19,6 +19,7 @@ import team.silvertown.masil.user.domain.UserAgreement;
 import team.silvertown.masil.user.domain.UserAuthority;
 import team.silvertown.masil.user.dto.LoginResponse;
 import team.silvertown.masil.user.dto.MeInfoResponse;
+import team.silvertown.masil.user.dto.NicknameCheckResponse;
 import team.silvertown.masil.user.dto.OAuthResponse;
 import team.silvertown.masil.user.dto.OnboardRequest;
 import team.silvertown.masil.user.exception.UserErrorCode;
@@ -91,10 +92,12 @@ public class UserService {
         updatingAuthority(authorities, user);
     }
 
-    public void checkNickname(String nickname) {
-        if (userRepository.existsByNickname(nickname)) {
-            throw new DuplicateResourceException(UserErrorCode.DUPLICATED_NICKNAME);
-        }
+    public NicknameCheckResponse checkNickname(String nickname) {
+        boolean isDuplicated = userRepository.existsByNickname(nickname);
+        return NicknameCheckResponse.builder()
+            .nickname(nickname)
+            .isDuplicated(isDuplicated)
+            .build();
     }
 
     public MeInfoResponse getMe(Long memberId) {

--- a/src/test/java/team/silvertown/masil/user/service/UserServiceTest.java
+++ b/src/test/java/team/silvertown/masil/user/service/UserServiceTest.java
@@ -32,6 +32,7 @@ import team.silvertown.masil.user.domain.User;
 import team.silvertown.masil.user.domain.UserAuthority;
 import team.silvertown.masil.user.dto.LoginResponse;
 import team.silvertown.masil.user.dto.MeInfoResponse;
+import team.silvertown.masil.user.dto.NicknameCheckResponse;
 import team.silvertown.masil.user.dto.OAuthResponse;
 import team.silvertown.masil.user.dto.OnboardRequest;
 import team.silvertown.masil.user.exception.UserErrorCode;
@@ -79,11 +80,13 @@ class UserServiceTest {
                 .fullName();
 
             //when, then
-            assertDoesNotThrow(() -> userService.checkNickname(nickname));
+            NicknameCheckResponse nicknameCheckResponse = userService.checkNickname(nickname);
+            assertThat(nicknameCheckResponse.isDuplicated()).isFalse();
+            assertThat(nicknameCheckResponse.nickname()).isEqualTo(nickname);
         }
 
         @Test
-        public void 중복닉네임_조회시_이미_존재하는_닉네임을_조회할_경우_예외가_발생한다() throws Exception {
+        public void 중복닉네임_조회시_이미_존재하는_닉네임을_조회할_경우_이미_존재하고_있음을_반환한다() throws Exception {
             //given
             String nickname = faker.name()
                 .fullName();
@@ -92,10 +95,12 @@ class UserServiceTest {
                 .build();
             userRepository.save(user);
 
-            //when, then
-            assertThatThrownBy(() -> userService.checkNickname(nickname))
-                .isInstanceOf(DuplicateResourceException.class)
-                .hasMessage(UserErrorCode.DUPLICATED_NICKNAME.getMessage());
+            //when
+            NicknameCheckResponse nicknameCheckResponse = userService.checkNickname(nickname);
+
+            //then
+            assertThat(nicknameCheckResponse.isDuplicated()).isTrue();
+            assertThat(nicknameCheckResponse.nickname()).isEqualTo(nickname);
         }
 
     }


### PR DESCRIPTION
## 🎫 관련 이슈
* Resolves #86 
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 주요 변경사항
닉네임 중복 조회 Response 변경
```java
@Builder
public record NicknameCheckResponse (
    Boolean isDuplicated,
    String nickname
){

}
```

이 방식으로 변경
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
