### PR TITLE
🔥 Front-end service origin CORS 설정

### DIFF
--- a/src/main/java/team/silvertown/masil/config/CORSProperties.java
+++ b/src/main/java/team/silvertown/masil/config/CORSProperties.java
@@ -1,0 +1,10 @@
+package team.silvertown.masil.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("cors")
+public record CORSProperties(
+    String serviceOrigin
+) {
+
+}

--- a/src/main/java/team/silvertown/masil/config/CORSProperties.java
+++ b/src/main/java/team/silvertown/masil/config/CORSProperties.java
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("cors")
 public record CORSProperties(
+    String localOrigin,
     String serviceOrigin
 ) {
 

--- a/src/main/java/team/silvertown/masil/config/CORSProperties.java
+++ b/src/main/java/team/silvertown/masil/config/CORSProperties.java
@@ -4,7 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("cors")
 public record CORSProperties(
-    String localOrigin,
     String serviceOrigin
 ) {
 

--- a/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
+++ b/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
@@ -17,10 +17,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping(API_PATTERN)
-            .allowedOrigins(
-                corsProperties.localOrigin(),
-                corsProperties.serviceOrigin()
-            )
+            .allowedOrigins(corsProperties.serviceOrigin())
             .allowedMethods(
                 HttpMethod.GET.name(),
                 HttpMethod.POST.name(),

--- a/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
+++ b/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
@@ -1,8 +1,8 @@
 package team.silvertown.masil.config;
 
-import io.swagger.v3.oas.models.PathItem.HttpMethod;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 

--- a/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
+++ b/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package team.silvertown.masil.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -7,12 +8,17 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebMvc
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private static final String API_PATTERN = "/api/**";
+
+    private final CORSProperties corsProperties;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
-            .allowedOrigins("http://localhost:3000");
+        registry.addMapping(API_PATTERN)
+            .allowedOrigins(corsProperties.serviceOrigin());
     }
 
 }

--- a/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
+++ b/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package team.silvertown.masil.config;
 
+import io.swagger.v3.oas.models.PathItem.HttpMethod;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -16,7 +17,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping(API_PATTERN)
-            .allowedOrigins(corsProperties.serviceOrigin());
+            .allowedOrigins(corsProperties.serviceOrigin())
+            .allowedMethods(
+                HttpMethod.GET.name(),
+                HttpMethod.POST.name(),
+                HttpMethod.PUT.name(),
+                HttpMethod.PATCH.name(),
+                HttpMethod.DELETE.name(),
+                HttpMethod.OPTIONS.name()
+            );
     }
 
 }

--- a/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
+++ b/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
@@ -3,11 +3,9 @@ package team.silvertown.masil.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@EnableWebMvc
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 

--- a/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
+++ b/src/main/java/team/silvertown/masil/config/WebMvcConfig.java
@@ -17,7 +17,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping(API_PATTERN)
-            .allowedOrigins(corsProperties.serviceOrigin())
+            .allowedOrigins(
+                corsProperties.localOrigin(),
+                corsProperties.serviceOrigin()
+            )
             .allowedMethods(
                 HttpMethod.GET.name(),
                 HttpMethod.POST.name(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,7 @@ jwt:
 server:
   port: ${SERVER_PORT}
 cors:
+  local-origin: http://localhost:3000
   service-origin: ${SERVICE_ORIGIN}
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,8 @@ jwt:
   token-validity-in-seconds: ${TOKEN_EXPIRATION}
 server:
   port: ${SERVER_PORT}
+cors:
+  service-origin: ${SERVICE_ORIGIN}
 springdoc:
   swagger-ui:
     path: /docs

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,6 @@ jwt:
 server:
   port: ${SERVER_PORT}
 cors:
-  local-origin: http://localhost:3000
   service-origin: ${SERVICE_ORIGIN}
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
- `YAML` 파일로 service origin을 설정하도록 변경

## 💡 기타사항

- 추후 CD 파이프라인 및 Github secret 설정이 필요
