### PR TITLE
⚙️  user update response 변경(업데이트 정보 내려주기, 프론트 요청)

### DIFF
--- a/src/main/java/team/silvertown/masil/user/controller/UserController.java
+++ b/src/main/java/team/silvertown/masil/user/controller/UserController.java
@@ -24,6 +24,7 @@ import team.silvertown.masil.user.dto.MeInfoResponse;
 import team.silvertown.masil.user.dto.NicknameCheckResponse;
 import team.silvertown.masil.user.dto.OnboardRequest;
 import team.silvertown.masil.user.dto.UpdateRequest;
+import team.silvertown.masil.user.dto.UpdateResponse;
 import team.silvertown.masil.user.service.UserService;
 
 @RestController
@@ -115,16 +116,23 @@ public class UserController {
     }
 
     @PutMapping("/api/v1/users")
-    public ResponseEntity<Void> updateInfo(
+    @SecurityRequirement(name = "토큰 받아오기")
+    @Operation(summary = "카카오 토큰으로 로그인")
+    @ApiResponse(
+        responseCode = "200",
+        description = "유저 정보 업데이트 요청",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = UpdateResponse.class)
+        )
+    )
+    public ResponseEntity<UpdateResponse> updateInfo(
         @RequestBody
         UpdateRequest updateRequest,
         @AuthenticationPrincipal
         Long memberId
     ) {
-        userService.updateInfo(memberId, updateRequest);
-
-        return ResponseEntity.noContent()
-            .build();
+        return ResponseEntity.ok(userService.updateInfo(memberId, updateRequest));
     }
 
 }

--- a/src/main/java/team/silvertown/masil/user/controller/UserController.java
+++ b/src/main/java/team/silvertown/masil/user/controller/UserController.java
@@ -116,11 +116,10 @@ public class UserController {
     }
 
     @PutMapping("/api/v1/users")
-    @SecurityRequirement(name = "토큰 받아오기")
-    @Operation(summary = "카카오 토큰으로 로그인")
+    @Operation(summary = "유저 정보 업데이트 요청")
     @ApiResponse(
         responseCode = "200",
-        description = "유저 정보 업데이트 요청",
+        description = "유저 정보 업데이트 요청 성공 후 바뀐 콘텐츠를 확인한다",
         content = @Content(
             mediaType = "application/json",
             schema = @Schema(implementation = UpdateResponse.class)

--- a/src/main/java/team/silvertown/masil/user/dto/UpdateResponse.java
+++ b/src/main/java/team/silvertown/masil/user/dto/UpdateResponse.java
@@ -1,0 +1,27 @@
+package team.silvertown.masil.user.dto;
+
+import java.time.LocalDate;
+import team.silvertown.masil.user.domain.User;
+
+public record UpdateResponse(
+    String nickname,
+    String sex,
+    LocalDate birthDate,
+    int height,
+    int weight,
+    String exerciseIntensity
+) {
+
+    public static UpdateResponse from(User user) {
+        return new UpdateResponse(
+            user.getNickname(),
+            user.getSex()
+                .name(),
+            user.getBirthDate(),
+            user.getHeight(),
+            user.getWeight(),
+            user.getExerciseIntensity()
+                .name());
+    }
+
+}

--- a/src/main/java/team/silvertown/masil/user/service/UserService.java
+++ b/src/main/java/team/silvertown/masil/user/service/UserService.java
@@ -23,6 +23,7 @@ import team.silvertown.masil.user.dto.NicknameCheckResponse;
 import team.silvertown.masil.user.dto.OAuthResponse;
 import team.silvertown.masil.user.dto.OnboardRequest;
 import team.silvertown.masil.user.dto.UpdateRequest;
+import team.silvertown.masil.user.dto.UpdateResponse;
 import team.silvertown.masil.user.exception.UserErrorCode;
 import team.silvertown.masil.user.repository.UserAgreementRepository;
 import team.silvertown.masil.user.repository.UserAuthorityRepository;
@@ -95,11 +96,12 @@ public class UserService {
     }
 
     @Transactional
-    public void updateInfo(Long memberId, UpdateRequest updateRequest) {
+    public UpdateResponse updateInfo(Long memberId, UpdateRequest updateRequest) {
         User user = userRepository.findById(memberId)
             .orElseThrow(() -> new DataNotFoundException(UserErrorCode.USER_NOT_FOUND));
         update(user, updateRequest);
-        user.toggleIsPublic();
+
+        return UpdateResponse.from(user);
     }
 
     public NicknameCheckResponse checkNickname(String nickname) {


### PR DESCRIPTION
## 🎫 관련 이슈

* Resolves #100 
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 주요 변경사항
- 유저 정보 업데이트 후 업데이트 된 유저 정보를 다시 내려주는 로직 작성(프론트 요청)
```java
public record UpdateResponse(
    String nickname,
    String sex,
    LocalDate birthDate,
    int height,
    int weight,
    String exerciseIntensity
) {

}
```
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
