### PR TITLE
⚙️ enum 값들을 가지는 경우 값을 포함하지 않은 경우 업데이트 하지 않게 만들기

### DIFF
--- a/src/main/java/team/silvertown/masil/user/domain/ExerciseIntensity.java
+++ b/src/main/java/team/silvertown/masil/user/domain/ExerciseIntensity.java
@@ -1,6 +1,7 @@
 package team.silvertown.masil.user.domain;
 
 import java.util.Arrays;
+import java.util.Objects;
 import team.silvertown.masil.common.exception.BadRequestException;
 import team.silvertown.masil.user.exception.UserErrorCode;
 
@@ -12,11 +13,16 @@ public enum ExerciseIntensity {
     SUPER_HIGH;
 
     public static ExerciseIntensity get(String value) {
-        return Arrays.stream(ExerciseIntensity.values())
-            .filter(exerciseIntensity -> exerciseIntensity.name()
-                .equals(value))
-            .findFirst()
-            .orElseThrow(() -> new BadRequestException(UserErrorCode.INVALID_EXERCISE_INTENSITY));
+        if (Objects.nonNull(value)) {
+            return Arrays.stream(ExerciseIntensity.values())
+                .filter(exerciseIntensity -> exerciseIntensity.name()
+                    .equals(value))
+                .findFirst()
+                .orElseThrow(
+                    () -> new BadRequestException(UserErrorCode.INVALID_EXERCISE_INTENSITY));
+        }
+
+        return null;
     }
 
 }

--- a/src/main/java/team/silvertown/masil/user/domain/ExerciseIntensity.java
+++ b/src/main/java/team/silvertown/masil/user/domain/ExerciseIntensity.java
@@ -13,16 +13,16 @@ public enum ExerciseIntensity {
     SUPER_HIGH;
 
     public static ExerciseIntensity get(String value) {
-        if (Objects.nonNull(value)) {
-            return Arrays.stream(ExerciseIntensity.values())
-                .filter(exerciseIntensity -> exerciseIntensity.name()
-                    .equals(value))
-                .findFirst()
-                .orElseThrow(
-                    () -> new BadRequestException(UserErrorCode.INVALID_EXERCISE_INTENSITY));
+        if (Objects.isNull(value)) {
+            return null;
         }
 
-        return null;
+        return Arrays.stream(ExerciseIntensity.values())
+            .filter(exerciseIntensity -> exerciseIntensity.name()
+                .equals(value))
+            .findFirst()
+            .orElseThrow(
+                () -> new BadRequestException(UserErrorCode.INVALID_EXERCISE_INTENSITY));
     }
 
 }

--- a/src/main/java/team/silvertown/masil/user/domain/Sex.java
+++ b/src/main/java/team/silvertown/masil/user/domain/Sex.java
@@ -1,6 +1,7 @@
 package team.silvertown.masil.user.domain;
 
 import java.util.Arrays;
+import java.util.Objects;
 import lombok.Getter;
 import team.silvertown.masil.common.exception.BadRequestException;
 import team.silvertown.masil.user.exception.UserErrorCode;
@@ -11,10 +12,14 @@ public enum Sex {
     FEMALE;
 
     public static Sex get(String value) {
-        return Arrays.stream(Sex.values())
-            .filter(sex -> sex.name()
-                .equals(value))
-            .findFirst()
-            .orElseThrow(() -> new BadRequestException(UserErrorCode.INVALID_SEX));
+        if (Objects.nonNull(value)) {
+            return Arrays.stream(Sex.values())
+                .filter(sex -> sex.name()
+                    .equals(value))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(UserErrorCode.INVALID_SEX));
+        }
+
+        return null;
     }
 }

--- a/src/main/java/team/silvertown/masil/user/domain/Sex.java
+++ b/src/main/java/team/silvertown/masil/user/domain/Sex.java
@@ -12,14 +12,14 @@ public enum Sex {
     FEMALE;
 
     public static Sex get(String value) {
-        if (Objects.nonNull(value)) {
-            return Arrays.stream(Sex.values())
-                .filter(sex -> sex.name()
-                    .equals(value))
-                .findFirst()
-                .orElseThrow(() -> new BadRequestException(UserErrorCode.INVALID_SEX));
+        if (Objects.isNull(value)) {
+            return null;
         }
 
-        return null;
+        return Arrays.stream(Sex.values())
+            .filter(sex -> sex.name()
+                .equals(value))
+            .findFirst()
+            .orElseThrow(() -> new BadRequestException(UserErrorCode.INVALID_SEX));
     }
 }

--- a/src/main/java/team/silvertown/masil/user/domain/User.java
+++ b/src/main/java/team/silvertown/masil/user/domain/User.java
@@ -83,9 +83,8 @@ public class User extends BaseEntity {
     }
 
     public void updateSex(String sex) {
-        if (UserValidator.validateSex(sex, UserErrorCode.INVALID_SEX)) {
-            this.sex = Sex.valueOf(sex);
-        }
+        Sex validatedSex = Sex.get(sex);
+        this.sex = validatedSex;
     }
 
     public void updateBirthDate(String birthDate) {
@@ -105,9 +104,8 @@ public class User extends BaseEntity {
     }
 
     public void updateExerciseIntensity(String exerciseIntensity) {
-        if (UserValidator.validateExerciseIntensity(exerciseIntensity)) {
-            this.exerciseIntensity = ExerciseIntensity.get(exerciseIntensity);
-        }
+        ExerciseIntensity validatedIntensity = ExerciseIntensity.get(exerciseIntensity);
+        this.exerciseIntensity = validatedIntensity;
     }
 
     public void toggleIsPublic() {

--- a/src/main/java/team/silvertown/masil/user/domain/User.java
+++ b/src/main/java/team/silvertown/masil/user/domain/User.java
@@ -78,34 +78,40 @@ public class User extends BaseEntity {
     private String socialId;
 
     public void updateNickname(String nickname) {
-        UserValidator.validateNickname(nickname, UserErrorCode.INVALID_NICKNAME);
-        this.nickname = nickname;
+        if (UserValidator.validateNickname(nickname, UserErrorCode.INVALID_NICKNAME)) {
+            this.nickname = nickname;
+        }
     }
 
     public void updateSex(String sex) {
-        UserValidator.validateSex(sex, UserErrorCode.INVALID_SEX);
-        this.sex = Sex.valueOf(sex);
+        if (UserValidator.validateSex(sex, UserErrorCode.INVALID_SEX)) {
+            this.sex = Sex.valueOf(sex);
+        }
     }
 
     public void updateBirthDate(String birthDate) {
-        UserValidator.validateBirthDate(birthDate, UserErrorCode.INVALID_BIRTH_DATE);
-        this.birthDate = DateValidator.parseDate(birthDate,
-            UserErrorCode.INVALID_BIRTH_DATE);
+        if (UserValidator.validateBirthDate(birthDate, UserErrorCode.INVALID_BIRTH_DATE)) {
+            this.birthDate = DateValidator.parseDate(birthDate,
+                UserErrorCode.INVALID_BIRTH_DATE);
+        }
     }
 
     public void updateHeight(Integer height) {
-        UserValidator.validateHeight(height, UserErrorCode.INVALID_HEIGHT);
-        this.height = height;
+        if (UserValidator.validateHeight(height, UserErrorCode.INVALID_HEIGHT)) {
+            this.height = height;
+        }
     }
 
     public void updateWeight(Integer weight) {
-        UserValidator.validateWeight(weight, UserErrorCode.INVALID_WEIGHT);
-        this.weight = weight;
+        if (UserValidator.validateWeight(weight, UserErrorCode.INVALID_WEIGHT)) {
+            this.weight = weight;
+        }
     }
 
     public void updateExerciseIntensity(String exerciseIntensity) {
-        UserValidator.validateExerciseIntensity(exerciseIntensity);
-        this.exerciseIntensity = ExerciseIntensity.valueOf(exerciseIntensity);
+        if (UserValidator.validateExerciseIntensity(exerciseIntensity)) {
+            this.exerciseIntensity = ExerciseIntensity.get(exerciseIntensity);
+        }
     }
 
     public void toggleIsPublic() {

--- a/src/main/java/team/silvertown/masil/user/domain/User.java
+++ b/src/main/java/team/silvertown/masil/user/domain/User.java
@@ -78,9 +78,8 @@ public class User extends BaseEntity {
     private String socialId;
 
     public void updateNickname(String nickname) {
-        if (UserValidator.validateNickname(nickname, UserErrorCode.INVALID_NICKNAME)) {
-            this.nickname = nickname;
-        }
+        UserValidator.validateNickname(nickname, UserErrorCode.INVALID_NICKNAME);
+        this.nickname = nickname;
     }
 
     public void updateSex(String sex) {

--- a/src/main/java/team/silvertown/masil/user/domain/User.java
+++ b/src/main/java/team/silvertown/masil/user/domain/User.java
@@ -89,22 +89,19 @@ public class User extends BaseEntity {
     }
 
     public void updateBirthDate(String birthDate) {
-        if (UserValidator.validateBirthDate(birthDate, UserErrorCode.INVALID_BIRTH_DATE)) {
-            this.birthDate = DateValidator.parseDate(birthDate,
-                UserErrorCode.INVALID_BIRTH_DATE);
-        }
+        UserValidator.validateBirthDate(birthDate, UserErrorCode.INVALID_BIRTH_DATE);
+        this.birthDate = DateValidator.parseDate(birthDate, UserErrorCode.INVALID_BIRTH_DATE);
+
     }
 
     public void updateHeight(Integer height) {
-        if (UserValidator.validateHeight(height, UserErrorCode.INVALID_HEIGHT)) {
-            this.height = height;
-        }
+        UserValidator.validateHeight(height, UserErrorCode.INVALID_HEIGHT);
+        this.height = height;
     }
 
     public void updateWeight(Integer weight) {
-        if (UserValidator.validateWeight(weight, UserErrorCode.INVALID_WEIGHT)) {
-            this.weight = weight;
-        }
+        UserValidator.validateWeight(weight, UserErrorCode.INVALID_WEIGHT);
+        this.weight = weight;
     }
 
     public void updateExerciseIntensity(String exerciseIntensity) {

--- a/src/main/java/team/silvertown/masil/user/service/UserService.java
+++ b/src/main/java/team/silvertown/masil/user/service/UserService.java
@@ -2,6 +2,7 @@ package team.silvertown.masil.user.service;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -74,7 +75,10 @@ public class UserService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new DataNotFoundException(UserErrorCode.USER_NOT_FOUND));
 
-        checkNickname(request.nickname());
+        if (userRepository.existsByNickname(request.nickname())) {
+            throw new DuplicateResourceException(UserErrorCode.DUPLICATED_NICKNAME);
+        }
+
         update(user, request);
         UserAgreement userAgreement = getUserAgreement(request, user);
         Validator.throwIf(agreementRepository.existsByUser(user),
@@ -98,6 +102,12 @@ public class UserService {
     public void updateInfo(Long memberId, UpdateRequest updateRequest) {
         User user = userRepository.findById(memberId)
             .orElseThrow(() -> new DataNotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        if (userRepository.existsByNickname(updateRequest.nickname()) && !user.getNickname()
+            .equals(updateRequest.nickname())) {
+            throw new DuplicateResourceException(UserErrorCode.DUPLICATED_NICKNAME);
+        }
+
         update(user, updateRequest);
         user.toggleIsPublic();
     }

--- a/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
+++ b/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
@@ -19,11 +19,10 @@ public class UserValidator extends Validator {
             () -> new DataNotFoundException(UserErrorCode.AUTHORITY_NOT_FOUND));
     }
 
-    public static boolean validateNickname(String nickname, UserErrorCode userErrorCode) {
+    public static void validateNickname(String nickname, UserErrorCode userErrorCode) {
         notBlank(nickname, userErrorCode);
         range(nickname.length(), 2, 12, userErrorCode);
         notMatching(nickname, VALID_NICKNAME_PATTERN, userErrorCode);
-        return true;
     }
 
     public static boolean validateSex(String sex, UserErrorCode userErrorCode) {

--- a/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
+++ b/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
@@ -25,15 +25,11 @@ public class UserValidator extends Validator {
         notMatching(nickname, VALID_NICKNAME_PATTERN, userErrorCode);
     }
 
-    public static boolean validateSex(String sex, UserErrorCode userErrorCode) {
+    public static void validateSex(String sex, UserErrorCode userErrorCode) {
         if (sex != null) {
             notBlank(sex, userErrorCode);
             Sex.get(sex);
-
-            return true;
         }
-
-        return false;
     }
 
     public static void validateBirthDate(String birthDate, UserErrorCode userErrorCode) {
@@ -55,15 +51,12 @@ public class UserValidator extends Validator {
         }
     }
 
-    public static boolean validateExerciseIntensity(
+    public static void validateExerciseIntensity(
         String exerciseIntensity
     ) {
         if (exerciseIntensity != null) {
             ExerciseIntensity.get(exerciseIntensity);
-            return true;
         }
-
-        return false;
     }
 
     public static void validateIsAllowingMarketing(

--- a/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
+++ b/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
@@ -29,41 +29,30 @@ public class UserValidator extends Validator {
         if (sex != null) {
             notBlank(sex, userErrorCode);
             Sex.get(sex);
+
             return true;
         }
 
         return false;
     }
 
-    public static boolean validateBirthDate(String birthDate, UserErrorCode userErrorCode) {
+    public static void validateBirthDate(String birthDate, UserErrorCode userErrorCode) {
         if (birthDate != null) {
             notBlank(birthDate, userErrorCode);
             DateValidator.parseDate(birthDate, userErrorCode);
-
-            return true;
         }
-
-        return false;
     }
 
-    public static boolean validateHeight(Integer height, UserErrorCode userErrorCode) {
+    public static void validateHeight(Integer height, UserErrorCode userErrorCode) {
         if (height != null) {
             notUnder(height, 1, userErrorCode);
-
-            return true;
         }
-
-        return false;
     }
 
-    public static boolean validateWeight(Integer weight, UserErrorCode userErrorCode) {
+    public static void validateWeight(Integer weight, UserErrorCode userErrorCode) {
         if (weight != null) {
             notUnder(weight, 1, userErrorCode);
-
-            return true;
         }
-
-        return false;
     }
 
     public static boolean validateExerciseIntensity(

--- a/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
+++ b/src/main/java/team/silvertown/masil/user/validator/UserValidator.java
@@ -19,44 +19,63 @@ public class UserValidator extends Validator {
             () -> new DataNotFoundException(UserErrorCode.AUTHORITY_NOT_FOUND));
     }
 
-    public static void validateNickname(String nickname, UserErrorCode userErrorCode) {
+    public static boolean validateNickname(String nickname, UserErrorCode userErrorCode) {
         notBlank(nickname, userErrorCode);
         range(nickname.length(), 2, 12, userErrorCode);
         notMatching(nickname, VALID_NICKNAME_PATTERN, userErrorCode);
+        return true;
     }
 
-    public static void validateSex(String sex, UserErrorCode userErrorCode) {
+    public static boolean validateSex(String sex, UserErrorCode userErrorCode) {
         if (sex != null) {
             notBlank(sex, userErrorCode);
             Sex.get(sex);
+            return true;
         }
+
+        return false;
     }
 
-    public static void validateBirthDate(String birthDate, UserErrorCode userErrorCode) {
+    public static boolean validateBirthDate(String birthDate, UserErrorCode userErrorCode) {
         if (birthDate != null) {
             notBlank(birthDate, userErrorCode);
             DateValidator.parseDate(birthDate, userErrorCode);
+
+            return true;
         }
+
+        return false;
     }
 
-    public static void validateHeight(Integer height, UserErrorCode userErrorCode) {
+    public static boolean validateHeight(Integer height, UserErrorCode userErrorCode) {
         if (height != null) {
             notUnder(height, 1, userErrorCode);
+
+            return true;
         }
+
+        return false;
     }
 
-    public static void validateWeight(Integer weight, UserErrorCode userErrorCode) {
+    public static boolean validateWeight(Integer weight, UserErrorCode userErrorCode) {
         if (weight != null) {
             notUnder(weight, 1, userErrorCode);
+
+            return true;
         }
+
+        return false;
     }
 
-    public static void validateExerciseIntensity(
+    public static boolean validateExerciseIntensity(
         String exerciseIntensity
     ) {
         if (exerciseIntensity != null) {
             ExerciseIntensity.get(exerciseIntensity);
+            return true;
         }
+
+        return false;
     }
 
     public static void validateIsAllowingMarketing(

--- a/src/test/java/team/silvertown/masil/user/service/UserServiceTest.java
+++ b/src/test/java/team/silvertown/masil/user/service/UserServiceTest.java
@@ -224,6 +224,33 @@ class UserServiceTest {
         }
 
         @Test
+        public void 성별과_운동강도를_입력하지_않은경우에도_정상적으로_업데이트된다() throws Exception {
+            //given
+            OnboardRequest noSexAndExerciseIntensity = new OnboardRequest(
+                "nickname",
+                null,
+                format.format(faker.date()
+                    .birthdayLocalDate(20, 40)),
+                getRandomInt(170, 190),
+                getRandomInt(70, 90),
+                null,
+                true,
+                true,
+                true,
+                true
+            );
+
+            //when
+            userService.onboard(unTypedUser.getId(), noSexAndExerciseIntensity);
+            User updatedUser = userRepository.findById(unTypedUser.getId())
+                .get();
+
+            //then
+            assertThat(updatedUser.getSex()).isNull();
+            assertThat(updatedUser.getExerciseIntensity()).isNull();
+        }
+
+        @Test
         public void 이미_사용중인_닉네임이_라면_예외가_발생한다() throws Exception {
             //given
             User user = User.builder().nickname("nickname").build();

--- a/src/test/java/team/silvertown/masil/user/service/UserServiceTest.java
+++ b/src/test/java/team/silvertown/masil/user/service/UserServiceTest.java
@@ -223,6 +223,24 @@ class UserServiceTest {
                 .contains(Authority.NORMAL);
         }
 
+        @Test
+        public void 이미_사용중인_닉네임이_라면_예외가_발생한다() throws Exception {
+            //given
+            User user = User.builder().nickname("nickname").build();
+            userRepository.save(user);
+            OnboardRequest request = getNormalRequest();
+            List<UserAuthority> beforeUpdatedAuthority = userAuthorityRepository.findByUser(
+                unTypedUser);
+            assertThat(beforeUpdatedAuthority).hasSize(1);
+            assertThat(beforeUpdatedAuthority.get(0)
+                .getAuthority()).isEqualTo(Authority.RESTRICTED);
+
+            //when, then
+            assertThatThrownBy(() -> userService.onboard(unTypedUser.getId(), request))
+                .isInstanceOf(DuplicateResourceException.class)
+                .hasMessage(UserErrorCode.DUPLICATED_NICKNAME.getMessage());
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
## 🎫 관련 이슈
*Resolves #105 
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 주요 변경사항
- 기존 유저 update 메서드들에서 필수 값이 아닌 값들은 null 로 넣어도 되게 설정
- 그러나 Enum type의 값들은 Enum.get() 과 같이 String을 enum으로 변경하는 메서드가 존재하여 예외가 발생
- 그래서 null 값이 아니어서 업데이트를 하는 경우에만 값을 갱신하도록 변경
    - 운동강도, 성별 모두에 적용시킴
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
