### PR TITLE
🐛 목록 조회 시 사이즈가 없으면 실패하는 버그 수정

### DIFF
--- a/src/main/java/team/silvertown/masil/common/scroll/dto/NormalListRequest.java
+++ b/src/main/java/team/silvertown/masil/common/scroll/dto/NormalListRequest.java
@@ -19,7 +19,7 @@ public final class NormalListRequest {
         String depth3,
         String order,
         String cursor,
-        int size
+        Integer size
     ) {
         this.depth1 = depth1;
         this.depth2 = depth2;

--- a/src/main/java/team/silvertown/masil/common/scroll/dto/ScrollRequest.java
+++ b/src/main/java/team/silvertown/masil/common/scroll/dto/ScrollRequest.java
@@ -1,5 +1,6 @@
 package team.silvertown.masil.common.scroll.dto;
 
+import java.util.Objects;
 import lombok.Getter;
 import team.silvertown.masil.common.scroll.OrderType;
 import team.silvertown.masil.common.validator.ScrollValidator;
@@ -16,7 +17,7 @@ public final class ScrollRequest {
     public ScrollRequest(
         String order,
         String cursor,
-        int size
+        Integer size
     ) {
         OrderType orderType = OrderType.get(order);
 
@@ -24,7 +25,7 @@ public final class ScrollRequest {
 
         this.order = orderType;
         this.cursor = cursor;
-        this.size = (size == 0) ? DEFAULT_SIZE : size;
+        this.size = Objects.isNull(size) ? DEFAULT_SIZE : size;
     }
 
 }

--- a/src/main/java/team/silvertown/masil/common/scroll/dto/ScrollRequest.java
+++ b/src/main/java/team/silvertown/masil/common/scroll/dto/ScrollRequest.java
@@ -7,6 +7,8 @@ import team.silvertown.masil.common.validator.ScrollValidator;
 @Getter
 public final class ScrollRequest {
 
+    private static final int DEFAULT_SIZE = 10;
+
     private final OrderType order;
     private final String cursor;
     private final int size;
@@ -22,7 +24,7 @@ public final class ScrollRequest {
 
         this.order = orderType;
         this.cursor = cursor;
-        this.size = size;
+        this.size = (size == 0) ? DEFAULT_SIZE : size;
     }
 
 }


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #123 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 사이즈 null 허용
* 사이즈가 null일 시 기본 사이즈 10으로 적용

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
