### PR TITLE
🐛 스웨거로 로그인 시 잘못된 설정 수정

### DIFF
--- a/src/main/java/team/silvertown/masil/user/controller/UserController.java
+++ b/src/main/java/team/silvertown/masil/user/controller/UserController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -94,6 +95,9 @@ public class UserController {
             mediaType = "application/json",
             schema = @Schema(implementation = LoginResponse.class)
         )
+    )
+    @SecurityRequirements(
+        @SecurityRequirement(name = "토큰 받아오기")
     )
     public ResponseEntity<LoginResponse> login(
         @RequestHeader(HttpHeaders.AUTHORIZATION)


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* NA
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 로그인 시 필요한 인증은 카카오 로그인
* 왠지 모르겠는데 빠져있네요
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
