### PR TITLE
🚀 메이트 상세조회 시 참여자 사용자 id와 포스트 id 추가

### DIFF
--- a/src/main/java/team/silvertown/masil/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/team/silvertown/masil/mate/dto/response/MateDetailResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.Builder;
 import team.silvertown.masil.common.map.KakaoPoint;
 import team.silvertown.masil.mate.domain.Mate;
+import team.silvertown.masil.post.domain.Post;
 
 @Builder
 public record MateDetailResponse(
@@ -18,10 +19,13 @@ public record MateDetailResponse(
     Integer capacity,
     Long authorId,
     String authorNickname,
-    String authorProfileUrl
+    String authorProfileUrl,
+    Long postId
 ) {
 
     public static MateDetailResponse from(Mate mate, List<ParticipantResponse> participants) {
+        Post post = mate.getPost();
+
         return MateDetailResponse.builder()
             .id(mate.getId())
             .title(mate.getTitle())
@@ -34,6 +38,7 @@ public record MateDetailResponse(
             .authorId(mate.getAuthor().getId())
             .authorNickname(mate.getAuthor().getNickname())
             .authorProfileUrl(mate.getAuthor().getProfileImg())
+            .postId(post.getId())
             .build();
     }
 

--- a/src/main/java/team/silvertown/masil/mate/dto/response/ParticipantResponse.java
+++ b/src/main/java/team/silvertown/masil/mate/dto/response/ParticipantResponse.java
@@ -3,20 +3,25 @@ package team.silvertown.masil.mate.dto.response;
 import lombok.Builder;
 import team.silvertown.masil.mate.domain.MateParticipant;
 import team.silvertown.masil.mate.domain.ParticipantStatus;
+import team.silvertown.masil.user.domain.User;
 
 @Builder
 public record ParticipantResponse(
     Long id,
+    Long userId,
     String nickname,
     String profileUrl,
     ParticipantStatus status
 ) {
 
     public static ParticipantResponse from(MateParticipant participant) {
+        User user = participant.getUser();
+
         return ParticipantResponse.builder()
             .id(participant.getId())
-            .nickname(participant.getUser().getNickname())
-            .profileUrl(participant.getUser().getProfileImg())
+            .userId(user.getId())
+            .nickname(user.getNickname())
+            .profileUrl(user.getProfileImg())
             .status(participant.getStatus())
             .build();
     }


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #134 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 메이트 상세조회 시 post id, 참여자들 user id 추가
* id만 조회하는거라 n+1 없습니다!
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
