### PR TITLE
🚀 API 서버 모니터링 서비스 Centry 적용

### DIFF
--- a/.github/workflows/cd-pipeline-dev.yml
+++ b/.github/workflows/cd-pipeline-dev.yml
@@ -40,7 +40,9 @@ jobs:
         env:
           server.port: ${{ env.SERVER_PORT }}
           cors.service-origin: ${{ secrets.SERVICE_ORIGIN }}
+          sentry.dsn: ${{ secrets.SENTRY_DSN }}
 
+          spring.datasource.driver-class-name: ${{ secrets.DRIVER_CLASS_NAME }}
           spring.datasource.username: ${{ secrets.MYSQL_USERNAME }}
           spring.datasource.password: ${{ secrets.MYSQL_PASSWORD }}
           spring.datasource.url: ${{ secrets.MYSQL_URL }}

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.0.0'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
 
+    // sentry
+    implementation 'io.sentry:sentry-jdbc:7.6.0'
+
     // snap admin
     implementation 'tech.ailef:snap-admin:0.2.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'checkstyle'
+    id "io.sentry.jvm.gradle" version "4.3.1"
 }
 
 group = 'team.silver-town'

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,7 +5,7 @@ logging:
 snapadmin:
   enabled: true
 sentry:
-  dsn: ${SENTRY_DSN}
+  enabled: true
   environment: dev
   enable-tracing: true
   traces-sample-rate: 1.0

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,12 @@ logging:
       SQL: debug
 snapadmin:
   enabled: true
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: dev
+  enable-tracing: true
+  traces-sample-rate: 1.0
+  debug: false
+  logging:
+    minimum-event-level: warn
+    minimum-breadcrumb-level: debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,3 +24,5 @@ spring:
         format_sql: true
 snapadmin:
   enabled: true
+sentry:
+  enabled: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,7 +15,7 @@ springdoc:
   swagger-ui:
     enabled: false
 sentry:
-  dsn: ${SENTRY_DSN}
+  enabled: true
   environment: prod
   enable-tracing: true
   traces-sample-rate: 1.0

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,3 +14,11 @@ logging:
 springdoc:
   swagger-ui:
     enabled: false
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: prod
+  enable-tracing: true
+  traces-sample-rate: 1.0
+  debug: false
+  logging:
+    minimum-event-level: error

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,5 @@ snapadmin:
   baseUrl: admin-panel
   modelsPackage: team.silvertown.masil
   sql-console-enabled: false
+sentry:
+  dsn: ${SENTRY_DSN}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     active: local
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: ${DRIVER_CLASS_NAME}
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     url: ${MYSQL_URL}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,3 +13,5 @@ spring:
       port: 6379
   flyway:
     enabled: false
+sentry:
+  enabled: false


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- Resolves #137 

## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->

- [x] sentry 서비스 적용
- [x] 서버 에러 로깅 트레이스
    
  <img width="2160" alt="image" src="https://github.com/Team-SilverTown/Team-SilverTown-MasilGasil-BE/assets/31983961/ee4b7720-1d31-4e4f-b3a4-bac496a126ab">

- [x] DB 쿼리 성능 조회
  
  <img width="2160" alt="image" src="https://github.com/Team-SilverTown/Team-SilverTown-MasilGasil-BE/assets/31983961/4ff66961-3989-49a8-b6f3-4daf4f73f65e">

## 💡 기타사항
- 무료 버전의 경우 팀 구성이 한 명으로 제한
- 추후 모니터링 관리자 계정 공유 예정
<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
