### PR TITLE
🚀 메이트 조회 시 상태 변경 추가

### DIFF
--- a/src/main/java/team/silvertown/masil/mate/domain/Mate.java
+++ b/src/main/java/team/silvertown/masil/mate/domain/Mate.java
@@ -124,4 +124,12 @@ public class Mate extends BaseEntity {
         return this.gathering.getGatheringAt();
     }
 
+    public void closeIfPassed() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        if (now.isAfter(this.gathering.getGatheringAt())) {
+            this.status = MateStatus.CLOSED;
+        }
+    }
+
 }

--- a/src/main/java/team/silvertown/masil/mate/dto/MateCursorDto.java
+++ b/src/main/java/team/silvertown/masil/mate/dto/MateCursorDto.java
@@ -1,9 +1,9 @@
 package team.silvertown.masil.mate.dto;
 
-import team.silvertown.masil.mate.dto.response.SimpleMateResponse;
+import team.silvertown.masil.mate.domain.Mate;
 
 public record MateCursorDto(
-    SimpleMateResponse mate,
+    Mate mate,
     String cursor
 ) {
 

--- a/src/main/java/team/silvertown/masil/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/team/silvertown/masil/mate/dto/response/MateDetailResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.Builder;
 import team.silvertown.masil.common.map.KakaoPoint;
 import team.silvertown.masil.mate.domain.Mate;
+import team.silvertown.masil.mate.domain.MateStatus;
 import team.silvertown.masil.post.domain.Post;
 
 @Builder
@@ -17,6 +18,7 @@ public record MateDetailResponse(
     OffsetDateTime gatheringAt,
     List<ParticipantResponse> participants,
     Integer capacity,
+    MateStatus status,
     Long authorId,
     String authorNickname,
     String authorProfileUrl,
@@ -35,6 +37,7 @@ public record MateDetailResponse(
             .gatheringAt(mate.getGatheringAt())
             .participants(participants)
             .capacity(mate.getCapacity())
+            .status(mate.getStatus())
             .authorId(mate.getAuthor().getId())
             .authorNickname(mate.getAuthor().getNickname())
             .authorProfileUrl(mate.getAuthor().getProfileImg())

--- a/src/main/java/team/silvertown/masil/mate/dto/response/SimpleMateResponse.java
+++ b/src/main/java/team/silvertown/masil/mate/dto/response/SimpleMateResponse.java
@@ -1,8 +1,12 @@
 package team.silvertown.masil.mate.dto.response;
 
 import java.time.OffsetDateTime;
+import lombok.Builder;
+import team.silvertown.masil.mate.domain.Mate;
 import team.silvertown.masil.mate.domain.MateStatus;
+import team.silvertown.masil.user.domain.User;
 
+@Builder
 public record SimpleMateResponse(
     Long id,
     String title,
@@ -13,5 +17,20 @@ public record SimpleMateResponse(
     String authorNickname,
     String authorProfileUrl
 ) {
+
+    public static SimpleMateResponse from(Mate mate) {
+        User author = mate.getAuthor();
+
+        return SimpleMateResponse.builder()
+            .id(mate.getId())
+            .title(mate.getTitle())
+            .gatheringAt(mate.getGatheringAt())
+            .status(mate.getStatus())
+            .capacity(mate.getCapacity())
+            .authorId(author.getId())
+            .authorNickname(author.getNickname())
+            .authorProfileUrl(author.getProfileImg())
+            .build();
+    }
 
 }

--- a/src/main/java/team/silvertown/masil/mate/repository/mate/MateQueryRepositoryImpl.java
+++ b/src/main/java/team/silvertown/masil/mate/repository/mate/MateQueryRepositoryImpl.java
@@ -16,7 +16,6 @@ import team.silvertown.masil.common.scroll.dto.ScrollRequest;
 import team.silvertown.masil.mate.domain.Mate;
 import team.silvertown.masil.mate.domain.QMate;
 import team.silvertown.masil.mate.dto.MateCursorDto;
-import team.silvertown.masil.mate.dto.response.SimpleMateResponse;
 import team.silvertown.masil.post.domain.Post;
 import team.silvertown.masil.user.domain.QUser;
 
@@ -90,22 +89,8 @@ public class MateQueryRepositoryImpl implements MateQueryRepository {
     private ConstructorExpression<MateCursorDto> projectMateCursor(StringExpression cursor) {
         return Projections.constructor(
             MateCursorDto.class,
-            projectSimpleMate(),
+            mate,
             cursor
-        );
-    }
-
-    private ConstructorExpression<SimpleMateResponse> projectSimpleMate() {
-        return Projections.constructor(
-            SimpleMateResponse.class,
-            mate.id,
-            mate.title,
-            mate.gathering.gatheringAt,
-            mate.status,
-            mate.capacity,
-            mate.author.id,
-            mate.author.nickname,
-            mate.author.profileImg
         );
     }
 


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #139 

## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 메이트 상세/목록 조회 시 상태 변경 코드 추가
* 모임시간이 과거면 상태를 `CLOSED`로 변경
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
* 오늘 오전 중으로 부탁을 해서 급하게 필요할 것 같습니다!
* 도서 관리 과제 때 했던게 생각이 나서 고민이 됐는데 일단 반영하고 나중에 더 나은 방안이 있다면 개선하는게 좋을 것 같습니다