### PR TITLE
🚀 메이트 참여자 신청 수락 API 구현

### DIFF
--- a/src/main/java/team/silvertown/masil/mate/controller/MateParticipantController.java
+++ b/src/main/java/team/silvertown/masil/mate/controller/MateParticipantController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import team.silvertown.masil.mate.dto.request.CreateMateParticipantRequest;
@@ -47,6 +48,24 @@ public class MateParticipantController {
 
         return ResponseEntity.created(uri)
             .body(response);
+    }
+
+    @PutMapping("/api/v1/mates/{id}/participants/{participantId}")
+    @Operation(summary = "메이트 참여 요청 수락")
+    @ApiResponse(
+        responseCode = "204",
+        description = "메이트 참여 요청 수락 성공"
+    )
+    public ResponseEntity<Void> acceptParticipant(
+        @PathVariable
+        Long id,
+        @PathVariable
+        Long participantId
+    ) {
+        mateService.acceptParticipation(id, participantId);
+
+        return ResponseEntity.noContent()
+            .build();
     }
 
 }

--- a/src/main/java/team/silvertown/masil/mate/controller/MateParticipantController.java
+++ b/src/main/java/team/silvertown/masil/mate/controller/MateParticipantController.java
@@ -57,12 +57,14 @@ public class MateParticipantController {
         description = "메이트 참여 요청 수락 성공"
     )
     public ResponseEntity<Void> acceptParticipant(
+        @AuthenticationPrincipal
+        Long authorId,
         @PathVariable
         Long id,
         @PathVariable
         Long participantId
     ) {
-        mateService.acceptParticipation(id, participantId);
+        mateService.acceptParticipation(authorId, id, participantId);
 
         return ResponseEntity.noContent()
             .build();

--- a/src/main/java/team/silvertown/masil/mate/domain/MateParticipant.java
+++ b/src/main/java/team/silvertown/masil/mate/domain/MateParticipant.java
@@ -61,4 +61,8 @@ public class MateParticipant extends BaseEntity {
         this.status = status;
     }
 
+    public void acceptParticipant() {
+        this.status = ParticipantStatus.ACCEPTED;
+    }
+
 }

--- a/src/main/java/team/silvertown/masil/mate/exception/MateErrorCode.java
+++ b/src/main/java/team/silvertown/masil/mate/exception/MateErrorCode.java
@@ -24,6 +24,8 @@ public enum MateErrorCode implements ErrorCode {
     MATE_NOT_FOUND(20400, "해당 아이디의 메이트가 존재하지 않습니다"),
 
     PARTICIPATING_AROUND_SIMILAR_TIME(30000, "비슷한 시간대에 참여하는 메이트가 있습니다"),
+    PARTICIPANT_MATE_NOT_MATCHING(30001, "해당 메이트의 메이트 참여자가 아닙니다"),
+    PARTICIPANT_NOT_FOUND(30400, "메이트 참여 정보가 존재하지 않습니다"),
 
     NULL_POST(40000, "메이트 모집의 산책로 포스트를 확인할 수 없습니다"),
     POST_NOT_FOUND(40400, "기존의 산책로 포스트를 찾을 수 없습니다"),

--- a/src/main/java/team/silvertown/masil/mate/exception/MateErrorCode.java
+++ b/src/main/java/team/silvertown/masil/mate/exception/MateErrorCode.java
@@ -32,6 +32,7 @@ public enum MateErrorCode implements ErrorCode {
 
     NULL_AUTHOR(90000, "메이트 모집의 작성자를 확인할 수 없습니다"),
     NULL_USER(90001, "해당 메이트 참여자를 확인할 수 없습니다"),
+    USER_NOT_AUTHORIZED_FOR_MATE(90300, "사용자는 해당 메이트 조작 권한이 없습니다"),
     USER_NOT_FOUND(90400, "사용자가 존재하지 않습니다");
 
     private static final int MATE_ERROR_CODE_PREFIX = 300_00000;

--- a/src/main/java/team/silvertown/masil/mate/repository/participant/MateParticipantQueryRepository.java
+++ b/src/main/java/team/silvertown/masil/mate/repository/participant/MateParticipantQueryRepository.java
@@ -2,6 +2,7 @@ package team.silvertown.masil.mate.repository.participant;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import team.silvertown.masil.mate.domain.Mate;
 import team.silvertown.masil.mate.domain.MateParticipant;
 import team.silvertown.masil.user.domain.User;
@@ -11,5 +12,7 @@ public interface MateParticipantQueryRepository {
     boolean existsInSimilarTime(User user, OffsetDateTime gatheringAt);
 
     List<MateParticipant> findAllByMate(Mate mate);
+
+    Optional<MateParticipant> findByIdWithMate(Long id);
 
 }

--- a/src/main/java/team/silvertown/masil/mate/repository/participant/MateParticipantQueryRepository.java
+++ b/src/main/java/team/silvertown/masil/mate/repository/participant/MateParticipantQueryRepository.java
@@ -13,6 +13,6 @@ public interface MateParticipantQueryRepository {
 
     List<MateParticipant> findAllByMate(Mate mate);
 
-    Optional<MateParticipant> findByIdWithMate(Long id);
+    Optional<MateParticipant> findWithMateById(Long id);
 
 }

--- a/src/main/java/team/silvertown/masil/mate/repository/participant/MateParticipantQueryRepositoryImpl.java
+++ b/src/main/java/team/silvertown/masil/mate/repository/participant/MateParticipantQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import team.silvertown.masil.mate.domain.Mate;
@@ -20,10 +21,10 @@ public class MateParticipantQueryRepositoryImpl implements MateParticipantQueryR
 
     private final JPAQueryFactory jpaQueryFactory;
     private final QMateParticipant mateParticipant = QMateParticipant.mateParticipant;
+    private final QMate mate = QMate.mate;
 
     @Override
     public boolean existsInSimilarTime(User user, OffsetDateTime gatheringAt) {
-        QMate mate = QMate.mate;
         OffsetDateTime beforeHour = gatheringAt.minusHours(1);
         OffsetDateTime afterHour = gatheringAt.plusHours(1);
         BooleanBuilder condition = new BooleanBuilder()
@@ -51,6 +52,16 @@ public class MateParticipantQueryRepositoryImpl implements MateParticipantQueryR
             .fetchJoin()
             .where(mateParticipant.mate.eq(mate))
             .fetch();
+    }
+
+    @Override
+    public Optional<MateParticipant> findByIdWithMate(Long id) {
+        return Optional.ofNullable(jpaQueryFactory
+            .selectFrom(mateParticipant)
+            .join(mateParticipant.mate, mate)
+            .fetchJoin()
+            .where(mateParticipant.id.eq(id))
+            .fetchFirst());
     }
 
 }

--- a/src/main/java/team/silvertown/masil/mate/repository/participant/MateParticipantQueryRepositoryImpl.java
+++ b/src/main/java/team/silvertown/masil/mate/repository/participant/MateParticipantQueryRepositoryImpl.java
@@ -55,7 +55,7 @@ public class MateParticipantQueryRepositoryImpl implements MateParticipantQueryR
     }
 
     @Override
-    public Optional<MateParticipant> findByIdWithMate(Long id) {
+    public Optional<MateParticipant> findWithMateById(Long id) {
         return Optional.ofNullable(jpaQueryFactory
             .selectFrom(mateParticipant)
             .join(mateParticipant.mate, mate)

--- a/src/main/java/team/silvertown/masil/mate/service/MateService.java
+++ b/src/main/java/team/silvertown/masil/mate/service/MateService.java
@@ -116,7 +116,7 @@ public class MateService {
 
     @Transactional
     public void acceptParticipation(Long authorId, Long id, Long participantId) {
-        MateParticipant mateParticipant = mateParticipantRepository.findByIdWithMate(participantId)
+        MateParticipant mateParticipant = mateParticipantRepository.findWithMateById(participantId)
             .orElseThrow(getNotFoundException(MateErrorCode.PARTICIPANT_NOT_FOUND));
 
         MateValidator.validateParticipantAcceptance(authorId, id, mateParticipant);

--- a/src/main/java/team/silvertown/masil/mate/service/MateService.java
+++ b/src/main/java/team/silvertown/masil/mate/service/MateService.java
@@ -115,17 +115,14 @@ public class MateService {
     }
 
     @Transactional
-    public void acceptParticipation(Long id, Long participantId) {
-        MateParticipant mateParticipant = mateParticipantRepository.findById(participantId)
+    public void acceptParticipation(Long authorId, Long id, Long participantId) {
+        MateParticipant mateParticipant = mateParticipantRepository.findByIdWithMate(participantId)
             .orElseThrow(getNotFoundException(MateErrorCode.PARTICIPANT_NOT_FOUND));
-        Mate mate = mateRepository.findById(id)
-            .orElseThrow(getNotFoundException(MateErrorCode.MATE_NOT_FOUND));
 
-        MateValidator.throwIf(!mate.equals(mateParticipant.getMate()),
-            () -> new BadRequestException(MateErrorCode.PARTICIPANT_MATE_NOT_MATCHING));
+        MateValidator.validateParticipantAcceptance(authorId, id, mateParticipant);
 
         boolean participatesAround = mateParticipantRepository.existsInSimilarTime(
-            mateParticipant.getUser(), mate.getGatheringAt());
+            mateParticipant.getUser(), mateParticipant.getMate().getGatheringAt());
 
         MateValidator.throwIf(participatesAround,
             () -> new DuplicateResourceException(MateErrorCode.PARTICIPATING_AROUND_SIMILAR_TIME));

--- a/src/main/java/team/silvertown/masil/mate/service/MateService.java
+++ b/src/main/java/team/silvertown/masil/mate/service/MateService.java
@@ -6,9 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team.silvertown.masil.common.exception.BadRequestException;
 import team.silvertown.masil.common.exception.DataNotFoundException;
-import team.silvertown.masil.common.exception.DuplicateResourceException;
 import team.silvertown.masil.common.exception.ErrorCode;
 import team.silvertown.masil.common.map.KakaoPointMapper;
 import team.silvertown.masil.common.scroll.dto.NormalListRequest;
@@ -47,12 +45,10 @@ public class MateService {
     public CreateMateResponse create(Long userId, CreateMateRequest request) {
         User author = userRepository.findById(userId)
             .orElseThrow(getNotFoundException(MateErrorCode.USER_NOT_FOUND));
-        boolean isParticipating = mateParticipantRepository.existsInSimilarTime(author,
+        boolean isParticipatingAnother = mateParticipantRepository.existsInSimilarTime(author,
             request.gatheringAt());
 
-        if (isParticipating) {
-            throw new BadRequestException(MateErrorCode.PARTICIPATING_AROUND_SIMILAR_TIME);
-        }
+        MateValidator.validateSoleParticipation(isParticipatingAnother);
 
         Post post = postRepository.findById(request.postId())
             .orElseThrow(getNotFoundException(MateErrorCode.POST_NOT_FOUND));
@@ -102,11 +98,10 @@ public class MateService {
         Mate mate = mateRepository.findById(id)
             .orElseThrow(getNotFoundException(MateErrorCode.MATE_NOT_FOUND));
 
-        boolean participatesAround = mateParticipantRepository.existsInSimilarTime(user,
+        boolean isParticipatingAnother = mateParticipantRepository.existsInSimilarTime(user,
             mate.getGatheringAt());
 
-        MateValidator.throwIf(participatesAround,
-            () -> new DuplicateResourceException(MateErrorCode.PARTICIPATING_AROUND_SIMILAR_TIME));
+        MateValidator.validateSoleParticipation(isParticipatingAnother);
 
         MateParticipant mateParticipant = createMateParticipant(user, mate,
             ParticipantStatus.REQUESTED, request.message());
@@ -121,11 +116,10 @@ public class MateService {
 
         MateValidator.validateParticipantAcceptance(authorId, id, mateParticipant);
 
-        boolean participatesAround = mateParticipantRepository.existsInSimilarTime(
+        boolean isParticipatingAnother = mateParticipantRepository.existsInSimilarTime(
             mateParticipant.getUser(), mateParticipant.getMate().getGatheringAt());
 
-        MateValidator.throwIf(participatesAround,
-            () -> new DuplicateResourceException(MateErrorCode.PARTICIPATING_AROUND_SIMILAR_TIME));
+        MateValidator.validateSoleParticipation(isParticipatingAnother);
 
         mateParticipant.acceptParticipant();
     }

--- a/src/main/java/team/silvertown/masil/mate/validator/MateValidator.java
+++ b/src/main/java/team/silvertown/masil/mate/validator/MateValidator.java
@@ -71,9 +71,9 @@ public final class MateValidator extends Validator {
     ) {
         notNull(mateId, MateErrorCode.NULL_MATE);
 
-        boolean isNotMatching = !mateId.equals(mate.getId());
+        boolean isNotMatchingMate = !mateId.equals(mate.getId());
 
-        throwIf(isNotMatching,
+        throwIf(isNotMatchingMate,
             () -> new BadRequestException(MateErrorCode.PARTICIPANT_MATE_NOT_MATCHING));
     }
 

--- a/src/main/java/team/silvertown/masil/mate/validator/MateValidator.java
+++ b/src/main/java/team/silvertown/masil/mate/validator/MateValidator.java
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import team.silvertown.masil.common.exception.BadRequestException;
+import team.silvertown.masil.common.exception.DuplicateResourceException;
 import team.silvertown.masil.common.exception.ForbiddenException;
 import team.silvertown.masil.common.validator.Validator;
 import team.silvertown.masil.mate.domain.Mate;
@@ -57,6 +58,11 @@ public final class MateValidator extends Validator {
 
         validateAuthForManipulation(authorId, mate);
         validateParticipantUnderMate(mateId, mate);
+    }
+
+    public static void validateSoleParticipation(boolean isParticipatingAnotherMate) {
+        throwIf(isParticipatingAnotherMate,
+            () -> new DuplicateResourceException(MateErrorCode.PARTICIPATING_AROUND_SIMILAR_TIME));
     }
 
     private static void validateParticipantUnderMate(

--- a/src/test/java/team/silvertown/masil/mate/service/MateServiceTest.java
+++ b/src/test/java/team/silvertown/masil/mate/service/MateServiceTest.java
@@ -155,7 +155,7 @@ class MateServiceTest {
         ThrowingCallable create = () -> mateService.create(author.getId(), request);
 
         // then
-        assertThatExceptionOfType(BadRequestException.class).isThrownBy(create)
+        assertThatExceptionOfType(DuplicateResourceException.class).isThrownBy(create)
             .withMessage(MateErrorCode.PARTICIPATING_AROUND_SIMILAR_TIME.getMessage());
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     open-in-view: false
+    show-sql: true
   data:
     redis:
       host: 127.0.0.1


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* #119 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* `PUT /api/v1/mates/{id}/participants/{participantId}`
* 작성자만 수락 권한 존재
* 비슷한 시간대에 참여하는 메이트 존재 시 수락 실패

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
* 4개의 select 쿼리가 필요했었는데
  * 로그인 사용자, 메이트, 메이트 참여자, 비슷한 시기의 메이트 참여 현황
* 이걸 두개로 줄이는 과정에서 로그인 사용자 select를 안 하고 아이디만 비교하고 있습니다
* mate는 그래도 괜찮을 것 같은데 로그인 사용자는 select를 할 필요가 있을까요?
* 만약 그렇다면 쿼리가 3개로 늘어날텐데 어쩔 수 없는 부분일까요?
* 지금 당장 이거 때문에 서비스 사용 시에 문제될 상황은 그려지지 않긴한데 고민은 되는 부분입니다