### PR TITLE
⚙️ user 가입 시 통계자료 모두 0으로 초기화

### DIFF
--- a/src/main/java/team/silvertown/masil/user/service/UserService.java
+++ b/src/main/java/team/silvertown/masil/user/service/UserService.java
@@ -190,6 +190,9 @@ public class UserService {
         return User.builder()
             .socialId(providerId)
             .provider(authenticatedProvider)
+            .totalCalories(0)
+            .totalCount(0)
+            .totalDistance(0)
             .isPublic(true)
             .build();
     }


### PR DESCRIPTION
## 🎫 관련 이슈

* Resolves #147 
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 주요 변경사항
- 유저 생성 시 통계자료를 모두 0으로 초기화
- 비공개 유저와 공개 유저를 구분하는 수단으로 쓰임
- 공개 유저의 경우 0으로 표기, 비공개 유저인 경우 마이페이지 입장 시 비공계 계정임을 표시하는 수단
- 현재 비공개 계정의 경우 builder에서 아예 통계 자료를 받지 않기 때문에 null 값으로 내려가 구분이 가능
- 유저 통계 자료도 생성할 때 0으로 만드는 것이 로직 상 맞다는 판단 하에 수정
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->

## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
