### PR TITLE
🐛 메이트 작성자가 상세 조회 시 참여자의 메세지가 null로 뜨는 버그 수정

### DIFF
--- a/src/main/java/team/silvertown/masil/mate/controller/MateController.java
+++ b/src/main/java/team/silvertown/masil/mate/controller/MateController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.Objects;
@@ -71,7 +70,6 @@ public class MateController {
             schema = @Schema(implementation = MateDetailResponse.class)
         )
     )
-    @SecurityRequirements
     public ResponseEntity<MateDetailResponse> getDetailById(
         @AuthenticationPrincipal
         Long userId,
@@ -115,7 +113,6 @@ public class MateController {
             )
         }
     )
-    @SecurityRequirements
     public ResponseEntity<ScrollResponse<SimpleMateResponse>> getScrollBy(
         @RequestParam(required = false)
         Long postId,

--- a/src/main/java/team/silvertown/masil/mate/dto/response/ParticipantResponse.java
+++ b/src/main/java/team/silvertown/masil/mate/dto/response/ParticipantResponse.java
@@ -20,6 +20,7 @@ public record ParticipantResponse(
 
         return ParticipantResponse.builder()
             .id(participant.getId())
+            .message(participant.getMessage())
             .userId(user.getId())
             .nickname(user.getNickname())
             .profileUrl(user.getProfileImg())

--- a/src/main/java/team/silvertown/masil/post/controller/PostController.java
+++ b/src/main/java/team/silvertown/masil/post/controller/PostController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.Objects;
@@ -72,7 +71,6 @@ public class PostController {
             schema = @Schema(implementation = PostDetailResponse.class)
         )
     )
-    @SecurityRequirements
     public ResponseEntity<PostDetailResponse> getById(
         @PathVariable
         Long id
@@ -119,7 +117,6 @@ public class PostController {
             )
         }
     )
-    @SecurityRequirements()
     public ResponseEntity<ScrollResponse<SimplePostResponse>> getScrollBy(
         @AuthenticationPrincipal
         Long loginId,

--- a/src/test/java/team/silvertown/masil/mate/service/MateServiceTest.java
+++ b/src/test/java/team/silvertown/masil/mate/service/MateServiceTest.java
@@ -81,7 +81,6 @@ class MateServiceTest {
     @BeforeEach
     void setUp() {
         author = userRepository.save(UserTexture.createValidUser());
-        // TODO: apply post texture
         post = postRepository.save(PostTexture.createDependentPost(author, 100));
         title = MateTexture.getRandomSentenceWithMax(30);
         content = MateTexture.getRandomSentenceWithMax(1000);
@@ -188,7 +187,7 @@ class MateServiceTest {
         MateDetailResponse actual = mateService.getDetailById(author.getId(), expected.getId());
 
         // then
-        ParticipantResponse expectedAuthor = ParticipantResponse.withoutMessageFrom(savedAuthor);
+        ParticipantResponse expectedAuthor = ParticipantResponse.withMessageFrom(savedAuthor);
 
         assertThat(actual)
             .hasFieldOrPropertyWithValue("id", expected.getId())


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #152 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 응답에 message 기입..
* 바보 같은 실수를 했습니다 ㅠㅠ
* 스웨거에서 security requirement를 안 거니까 아예 토큰을 안 받는거로 api 콜을 하더라고요. 그래서 지웠습니다
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
