### PR TITLE
🚀 산책로 포스트 조회 시 좋아요 여부 표시 추가

### DIFF
--- a/src/main/java/team/silvertown/masil/post/controller/PostController.java
+++ b/src/main/java/team/silvertown/masil/post/controller/PostController.java
@@ -72,10 +72,12 @@ public class PostController {
         )
     )
     public ResponseEntity<PostDetailResponse> getById(
+        @AuthenticationPrincipal
+        Long userId,
         @PathVariable
         Long id
     ) {
-        PostDetailResponse response = postService.getById(id);
+        PostDetailResponse response = postService.getById(userId, id);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/team/silvertown/masil/post/controller/PostLikeController.java
+++ b/src/main/java/team/silvertown/masil/post/controller/PostLikeController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.Objects;
@@ -34,19 +33,20 @@ public class PostLikeController {
         produces = MediaType.APPLICATION_JSON_VALUE
     )
     @Operation(summary = "산책로 포스트 좋아요")
-    @ApiResponses({
-        @ApiResponse(
-            responseCode = "200",
-            description = "좋아요 데이터 변경",
-            content = @Content(schema = @Schema(implementation = SaveLikeDto.class))
-        ),
-        @ApiResponse(
-            responseCode = "201",
-            description = "최초 좋아요 데이터 생성",
-            content = @Content(schema = @Schema(implementation = SaveLikeDto.class))
-        ),
-    })
-    @SecurityRequirements
+    @ApiResponses(
+        {
+            @ApiResponse(
+                responseCode = "200",
+                description = "좋아요 데이터 변경",
+                content = @Content(schema = @Schema(implementation = SaveLikeDto.class))
+            ),
+            @ApiResponse(
+                responseCode = "201",
+                description = "최초 좋아요 데이터 생성",
+                content = @Content(schema = @Schema(implementation = SaveLikeDto.class))
+            ),
+        }
+    )
     public ResponseEntity<SaveLikeDto> save(
         @AuthenticationPrincipal
         Long userId,

--- a/src/main/java/team/silvertown/masil/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/team/silvertown/masil/post/dto/response/PostDetailResponse.java
@@ -24,10 +24,15 @@ public record PostDetailResponse(
     List<PostPinDetailResponse> pins,
     long authorId,
     String authorName,
-    String thumbnailUrl
+    String thumbnailUrl,
+    boolean isLiked
 ) {
 
-    public static PostDetailResponse from(Post post, List<PostPinDetailResponse> pins) {
+    public static PostDetailResponse from(
+        Post post,
+        List<PostPinDetailResponse> pins,
+        boolean isLiked
+    ) {
         User author = post.getUser();
 
         return PostDetailResponse.builder()
@@ -48,6 +53,7 @@ public record PostDetailResponse(
             .authorId(author.getId())
             .authorName(author.getNickname())
             .thumbnailUrl(post.getThumbnailUrl())
+            .isLiked(isLiked)
             .build();
     }
 

--- a/src/main/java/team/silvertown/masil/post/dto/response/SimplePostResponse.java
+++ b/src/main/java/team/silvertown/masil/post/dto/response/SimplePostResponse.java
@@ -29,6 +29,22 @@ public final class SimplePostResponse {
         Integer likeCount,
         String thumbnailUrl
     ) {
+        this(id, address, title, content, totalTime, distance, viewCount, likeCount, thumbnailUrl,
+            false);
+    }
+
+    public SimplePostResponse(
+        Long id,
+        Address address,
+        String title,
+        String content,
+        Integer totalTime,
+        Integer distance,
+        Integer viewCount,
+        Integer likeCount,
+        String thumbnailUrl,
+        boolean isLiked
+    ) {
         this.id = id;
         this.address = address;
         this.title = title;
@@ -38,7 +54,7 @@ public final class SimplePostResponse {
         this.viewCount = viewCount;
         this.likeCount = likeCount;
         this.thumbnailUrl = thumbnailUrl;
-        this.isLiked = false;
+        this.isLiked = isLiked;
         this.hasMate = false;
     }
 

--- a/src/main/java/team/silvertown/masil/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/team/silvertown/masil/post/repository/PostQueryRepositoryImpl.java
@@ -159,27 +159,27 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
     ) {
         return Projections.constructor(
             PostCursorDto.class,
-            Objects.isNull(user) ? projectSimplePost() : projectSimplePostWithLike(),
+            projectSimplePost(user),
             cursor
         );
     }
 
-    private ConstructorExpression<SimplePostResponse> projectSimplePost() {
-        return Projections.constructor(
-            SimplePostResponse.class,
-            post.id,
-            post.address,
-            post.title,
-            post.content,
-            post.totalTime,
-            post.distance,
-            post.viewCount,
-            post.likeCount,
-            post.thumbnailUrl
-        );
-    }
+    private ConstructorExpression<SimplePostResponse> projectSimplePost(User user) {
+        if (Objects.isNull(user)) {
+            return Projections.constructor(
+                SimplePostResponse.class,
+                post.id,
+                post.address,
+                post.title,
+                post.content,
+                post.totalTime,
+                post.distance,
+                post.viewCount,
+                post.likeCount,
+                post.thumbnailUrl
+            );
+        }
 
-    private ConstructorExpression<SimplePostResponse> projectSimplePostWithLike() {
         return Projections.constructor(
             SimplePostResponse.class,
             post.id,

--- a/src/main/java/team/silvertown/masil/post/service/PostService.java
+++ b/src/main/java/team/silvertown/masil/post/service/PostService.java
@@ -15,6 +15,7 @@ import team.silvertown.masil.common.scroll.dto.NormalListRequest;
 import team.silvertown.masil.common.scroll.dto.ScrollRequest;
 import team.silvertown.masil.common.scroll.dto.ScrollResponse;
 import team.silvertown.masil.post.domain.Post;
+import team.silvertown.masil.post.domain.PostLikeId;
 import team.silvertown.masil.post.domain.PostPin;
 import team.silvertown.masil.post.domain.PostViewHistory;
 import team.silvertown.masil.post.dto.PostCursorDto;
@@ -25,6 +26,7 @@ import team.silvertown.masil.post.dto.response.PostDetailResponse;
 import team.silvertown.masil.post.dto.response.PostPinDetailResponse;
 import team.silvertown.masil.post.dto.response.SimplePostResponse;
 import team.silvertown.masil.post.exception.PostErrorCode;
+import team.silvertown.masil.post.repository.PostLikeRepository;
 import team.silvertown.masil.post.repository.PostPinRepository;
 import team.silvertown.masil.post.repository.PostRepository;
 import team.silvertown.masil.post.repository.PostViewHistoryRepository;
@@ -39,6 +41,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostPinRepository postPinRepository;
     private final PostViewHistoryRepository postViewHistoryRepository;
+    private final PostLikeRepository postLikeRepository;
 
     @Transactional
     public CreatePostResponse create(Long userId, CreatePostRequest request) {
@@ -52,14 +55,16 @@ public class PostService {
     }
 
     @Transactional
-    public PostDetailResponse getById(Long id) {
+    public PostDetailResponse getById(Long userId, Long id) {
         Post post = postRepository.findById(id)
             .orElseThrow(getNotFoundException(PostErrorCode.POST_NOT_FOUND));
         List<PostPinDetailResponse> pins = PostPinDetailResponse.listFrom(post);
+        PostLikeId postLikeId = new PostLikeId(userId, id);
+        boolean isLiked = postLikeRepository.existsById(postLikeId);
 
         increasePostViewCount(post);
 
-        return PostDetailResponse.from(post, pins);
+        return PostDetailResponse.from(post, pins, isLiked);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #158 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 단일 조회 시
  * 아이디로 postLikeRepository 조회
* 목록 조회 시
  * 기존 쿼리에 로그인 사용자 존재 시 join 추가
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
