### PR TITLE
🐛 포스트 단일 조회 시 좋아요 잘못 나오는 버그 수정

### DIFF
--- a/src/main/java/team/silvertown/masil/post/dto/response/SimplePostResponse.java
+++ b/src/main/java/team/silvertown/masil/post/dto/response/SimplePostResponse.java
@@ -1,5 +1,7 @@
 package team.silvertown.masil.post.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import lombok.AccessLevel;
 import lombok.Getter;
 import team.silvertown.masil.common.map.Address;
 
@@ -15,8 +17,10 @@ public final class SimplePostResponse {
     private final Integer viewCount;
     private final Integer likeCount;
     private final String thumbnailUrl;
-    private final boolean isLiked;
     private final boolean hasMate;
+
+    @Getter(AccessLevel.NONE)
+    private final boolean isLiked;
 
     public SimplePostResponse(
         Long id,
@@ -56,6 +60,11 @@ public final class SimplePostResponse {
         this.thumbnailUrl = thumbnailUrl;
         this.isLiked = isLiked;
         this.hasMate = false;
+    }
+
+    @JsonGetter("isLiked")
+    public boolean isLiked() {
+        return this.isLiked;
     }
 
 }

--- a/src/main/java/team/silvertown/masil/post/service/PostService.java
+++ b/src/main/java/team/silvertown/masil/post/service/PostService.java
@@ -15,6 +15,7 @@ import team.silvertown.masil.common.scroll.dto.NormalListRequest;
 import team.silvertown.masil.common.scroll.dto.ScrollRequest;
 import team.silvertown.masil.common.scroll.dto.ScrollResponse;
 import team.silvertown.masil.post.domain.Post;
+import team.silvertown.masil.post.domain.PostLike;
 import team.silvertown.masil.post.domain.PostLikeId;
 import team.silvertown.masil.post.domain.PostPin;
 import team.silvertown.masil.post.domain.PostViewHistory;
@@ -60,7 +61,9 @@ public class PostService {
             .orElseThrow(getNotFoundException(PostErrorCode.POST_NOT_FOUND));
         List<PostPinDetailResponse> pins = PostPinDetailResponse.listFrom(post);
         PostLikeId postLikeId = new PostLikeId(userId, id);
-        boolean isLiked = postLikeRepository.existsById(postLikeId);
+        boolean isLiked = postLikeRepository.findById(postLikeId)
+            .orElseGet(() -> new PostLike(null, false, false))
+            .isLike();
 
         increasePostViewCount(post);
 


### PR DESCRIPTION
## 🎫 관련 이슈

<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #160 
## 🚀 주요 변경사항

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을..-->
* 포스트 단일 조회 시 좋아요 유무 확인 대신 실제 좋아요 데이터의 값 응답
## 💡 기타사항

<!-- ex) 질문. 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
